### PR TITLE
ci: allow reusable workflow pull request reads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
     uses: ./.github/workflows/ci.yml
     permissions:
       contents: read
+      pull-requests: read
     secrets: inherit
 
   create-tag:


### PR DESCRIPTION
## Summary

- Allow the `Release` workflow's reusable `CI` call to request `pull-requests: read`.
- Keep the caller token read-only while matching the permissions declared by the called `ci.yml` workflow.

## Why

PR #28 did trigger a `Release` workflow run on merge, but GitHub marked it as `startup_failure` before creating jobs. The reusable workflow caller only allowed `contents: read`, while the called workflow contains the `Release PR Policy` job with `pull-requests: read`.

## Validation

- `/tmp/xtrinode-tools/actionlint -color=false .github/workflows/ci.yml .github/workflows/release.yml`
- `git diff --check`