### PR TITLE
docs: add community governance templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,122 @@
+name: Bug report
+description: Report a reproducible XTrinode defect or regression.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Do not include secrets,
+        credentials, auth headers, kubeconfigs, Terraform state, or sensitive
+        cluster details. Use the private security reporting path for security
+        vulnerabilities.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Select the closest affected area.
+      options:
+        - Operator
+        - API Server
+        - Gateway
+        - Catalogs and connectors
+        - Helm charts
+        - Terraform or cloud deployment
+        - CI or release automation
+        - Documentation or examples
+        - Unsure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: Provide the release version, image tag, chart version, or commit SHA.
+      placeholder: "v0.1.0, 0.1.0, or abc1234"
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment path
+      description: Where did this happen?
+      options:
+        - Local k3d/Tilt
+        - GKE or GCP Terraform
+        - AWS
+        - Azure
+        - Existing Kubernetes cluster
+        - CI
+        - Not deployment-related
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the defect and the observed behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should XTrinode have done instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Provide the shortest reliable reproduction path.
+      placeholder: |
+        1. Apply this manifest or run this command...
+        2. Wait for...
+        3. Observe...
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant configuration
+      description: Add redacted manifests, Helm values, Terraform snippets, or flags.
+      render: yaml
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or events
+      description: Add redacted logs, Kubernetes events, status conditions, or command output.
+      render: shell
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      options:
+        - Blocks installation or upgrade
+        - Breaks query routing or runtime availability
+        - Causes incorrect reconciliation or scaling
+        - Causes confusing status, metrics, or documentation
+        - Minor issue or papercut
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Checks already run
+      description: List any commands or diagnostics you already ran.
+      placeholder: "make ci-test, kubectl describe, helm template, ..."
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I checked existing issues and discussions for duplicates.
+          required: true
+        - label: I have removed secrets, tokens, kubeconfigs, Terraform state, and sensitive cluster details.
+          required: true
+        - label: This is not a security vulnerability report with exploit details.
+          required: true
+        - label: I agree to follow the XTrinode Code of Conduct.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and design discussions
+    url: https://github.com/xtrinode/xtrinode/discussions
+    about: Use Discussions for support questions, design exploration, and open-ended ideas.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,74 @@
+name: Documentation issue
+description: Report missing, stale, unclear, or overclaiming documentation.
+title: "[Docs]: "
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for documentation gaps, incorrect instructions, unclear
+        examples, or claims that do not match current XTrinode behavior.
+  - type: input
+    id: page
+    attributes:
+      label: Page or file
+      description: Link or name the documentation page, README section, example, or chart values file.
+      placeholder: "docs/DEPLOYMENT.md, README.md#security, helm/xtrinode/values.yaml"
+    validations:
+      required: true
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Documentation problem
+      options:
+        - Missing information
+        - Incorrect or stale instructions
+        - Overclaim or unsupported behavior
+        - Confusing wording
+        - Broken link or missing reference
+        - Example does not work
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current behavior or wording
+      description: Describe what the documentation says now, or what is missing.
+    validations:
+      required: true
+  - type: textarea
+    id: requested
+    attributes:
+      label: Requested change
+      description: Describe the documentation change you want.
+    validations:
+      required: true
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Primary audience
+      options:
+        - New users
+        - Operators
+        - Contributors
+        - Release maintainers
+        - Cloud deployers
+        - Unsure
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add links, command output, screenshots, or related issues.
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I checked existing issues and discussions for duplicates.
+          required: true
+        - label: I agree to follow the XTrinode Code of Conduct.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,81 @@
+name: Feature request
+description: Propose a focused enhancement or new XTrinode capability.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for concrete enhancements. For broad design exploration or
+        support questions, start a Discussion instead.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Select the closest area for the requested change.
+      options:
+        - Operator
+        - API Server
+        - Gateway
+        - Catalogs and connectors
+        - Helm charts
+        - Terraform or cloud deployment
+        - Observability
+        - Local development or e2e
+        - CI or release automation
+        - Documentation or examples
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What user or operator problem should this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the smallest useful version of the feature.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe workarounds or designs that should not be used, if any.
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and non-goals
+      description: What should this issue include, and what should it explicitly avoid?
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete outcomes that would close this issue.
+      placeholder: |
+        - ...
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification targets
+      description: Name existing or new checks that should validate the change.
+      placeholder: "make ci-test, make lint-helm, test-e2e-local-..."
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I checked existing issues and discussions for duplicates.
+          required: true
+        - label: This request has a concrete user or operator use case.
+          required: true
+        - label: I agree to follow the XTrinode Code of Conduct.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+- <!-- What changed and why? -->
+
+## Validation
+
+- [ ] Relevant local checks passed.
+- [ ] Skipped checks are explained below.
+
+## Risk
+
+- <!-- User impact, rollout risk, compatibility notes, or "Low". -->
+
+## Release Impact
+
+- [ ] This PR does not change release versioning, image publishing, or Helm chart packaging.
+- [ ] This PR changes release behavior and the impact is described below.
+
+## Notes
+
+- <!-- Links, follow-ups, screenshots, or anything reviewers should know. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# XTrinode Code of Conduct
+
+## Our Standard
+
+XTrinode is a technical project for Kubernetes, Trino, Gateway, and cloud deployment work. Project
+spaces should stay professional, direct, and useful.
+
+Expected behavior:
+
+- Be respectful and precise when discussing ideas, code, bugs, and operations.
+- Focus review comments on correctness, maintainability, security, reliability, and user impact.
+- Assume public conversations may be read by new contributors and operators evaluating the project.
+- Keep sensitive information out of public issues, discussions, pull requests, and logs.
+
+Unacceptable behavior:
+
+- Harassment, threats, personal attacks, or discriminatory language.
+- Publishing private information, credentials, tokens, kubeconfigs, or exploit details.
+- Repeated off-topic comments that make issue or review threads hard to use.
+- Bad-faith reports, spam, or attempts to disrupt project infrastructure.
+
+## Enforcement
+
+Maintainers may edit, hide, or remove comments; close or lock threads; block users; or report abuse to
+GitHub when behavior harms the project or its contributors.
+
+If you need to report conduct concerns, contact the maintainers through GitHub. Do not include
+security-sensitive details in a public conduct report.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+XTrinode is pre-1.0. Until stable releases are published, security fixes target the default branch
+and the latest published release tag when practical.
+
+| Version | Supported |
+| --- | --- |
+| `main` | Yes |
+| Latest release | Best effort |
+| Older releases | No |
+
+## Reporting a Vulnerability
+
+Do not publish secrets, credentials, exploit details, raw auth headers, kubeconfigs, Terraform state,
+or sensitive cluster configuration in public issues, discussions, pull requests, or logs.
+
+Preferred reporting path:
+
+1. Use GitHub private vulnerability reporting from the repository Security tab when available.
+2. If private reporting is not available, open a minimal public issue that says a security contact
+   path is needed. Do not include exploit details or sensitive artifacts in that issue.
+
+Include the following when it is safe to share privately:
+
+- Affected component: Operator, API Server, Gateway, Helm, Terraform, CI, or documentation.
+- Affected version, image tag, chart version, or commit SHA.
+- Impact and whether the issue is remotely reachable.
+- Minimal reproduction steps with secrets and cluster identifiers removed.
+- Suggested fix or mitigation, if known.
+
+## Response Expectations
+
+Maintainers will triage reports as project capacity allows. For confirmed vulnerabilities, fixes
+should prefer the smallest patch that removes the risk without exposing report details before users
+have a reasonable update path.
+
+## Security Scope
+
+Security-sensitive areas include authentication, token handling, CORS, gateway routing, Kubernetes
+RBAC, generated manifests, image publishing, release tagging, Terraform state, Secret handling, and
+any path that could expose Trino queries, catalogs, or credentials.


### PR DESCRIPTION
## Summary

- Add GitHub issue forms for bug reports, feature requests, and documentation issues.
- Add a pull request template with validation, risk, and release-impact prompts.
- Add initial `SECURITY.md` and `CODE_OF_CONDUCT.md` files for public contribution hygiene.

## Why

The repository is now public and accepts issues, discussions, and pull requests. These templates give contributors a clear path for reporting defects, proposing focused enhancements, and handling security-sensitive information without posting secrets or exploit details publicly.

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/docs.yml .github/ISSUE_TEMPLATE/config.yml`\n- Issue form sanity check for required keys, supported body types, and unique IDs\n- `make lint-markdown`\n- `git diff --cached --check`