### PR TITLE
Add query-aware drain and lifecycle observability

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -137,6 +137,57 @@ kubectl get endpoints trino-<runtime> -n <namespace>
 - Verify the `X-Trino-XTrinode` header, hostname, or default route matches the routing rule
 - Check gateway logs for routing errors
 
+## Runtime Deletion Stuck Draining
+
+**Symptoms**: A deleted XTrinode keeps its finalizer and the Gateway route shows the backend as
+`DRAINING`.
+
+**Diagnosis**:
+
+```bash
+kubectl describe xtrinode <runtime> -n <namespace>
+kubectl get configmap trino-gateway-routes -n xtrinode-gateway -o yaml
+kubectl logs -n xtrinode-system -l app.kubernetes.io/name=xtrinode-operator -f
+
+# If the coordinator is still reachable, inspect Trino's query endpoint.
+kubectl run trino-query-check -n <namespace> --rm -it --image=curlimages/curl -- \
+  curl -sS http://trino-<runtime>.<namespace>.svc.cluster.local:8080/v1/query \
+  -H 'X-Trino-User: xtrinode-operator'
+```
+
+**Behavior**:
+
+- The operator marks the Gateway backend `DRAINING` so new queries are not selected.
+- Each reconcile checks the coordinator `/v1/query` endpoint. If no `QUEUED` or `RUNNING` queries
+  remain, cleanup can start before the fallback window ends.
+- If the query endpoint is unavailable, the operator waits for the configured drain window
+  (`xtrinode-operator.operator.lifecycle.drainDuration`, `5m` by default) and then uses that
+  elapsed time as the fallback.
+- If the query endpoint reports active queries, the operator keeps waiting rather than removing the
+  backend.
+- The query-aware recheck interval is configured with
+  `xtrinode-operator.operator.lifecycle.drainRequeueInterval` and defaults to `30s`.
+- Drain progress is tracked on the XTrinode with `drain-started-at`, `drain-completed-at`, and
+  `drain-result` annotations under the `xtrinode.analytics.xtrinode.io/` prefix.
+
+**Useful metrics**:
+
+- `xtrinode_drain_active{namespace,name}` shows runtimes currently draining.
+- `xtrinode_drain_duration_seconds{namespace,name,result}` records completed drain duration. The
+  `result` label is `query_complete` or `time_fallback`.
+- `xtrinode_drain_failures_total{namespace,name,reason}` records failed drain starts, bad
+  annotations, or query-check failures.
+- `xtrinode_api_k8s_lease_acquired_total`, `xtrinode_api_k8s_lease_gated_total`, and
+  `xtrinode_api_k8s_lease_errors_total` show API server lifecycle gate outcomes.
+
+**Emergency override policy**:
+
+Do not hand-edit the shared Gateway route ConfigMap during ordinary operations. Any future manual
+state override must be an explicit emergency-only path with admin authentication, Kubernetes events
+or equivalent audit records, a clear target runtime, bounded cleanup or expiry behavior, and
+operator-owned reconciliation back to the normal state. Capture `kubectl describe`, events, and
+operator logs before considering a break-glass action.
+
 ## KEDA ScaledObject Not Triggering
 
 **Symptoms**: KEDA shows "unknown" status or not scaling

--- a/helm/xtrinode-observability/README.md
+++ b/helm/xtrinode-observability/README.md
@@ -8,6 +8,15 @@ This chart owns the GCP/local observability stack for XTrinode:
 The chart intentionally disables generic cluster infrastructure monitors by default (`nodeExporter`,
 kubelet, API server, scheduler, etc.) so it can coexist with an existing cluster monitoring stack.
 XTrinode charts render their own `ServiceMonitor` resources when Prometheus is enabled.
+This chart also renders an optional Grafana dashboard ConfigMap for lifecycle drain state and API
+server Lease acquired/gated/error outcomes. It is enabled by default with the
+`grafana_dashboard=1` label used by the Grafana sidecar.
+
+The dashboard can be disabled with:
+
+```sh
+--set dashboards.enabled=false
+```
 
 Install directly:
 

--- a/helm/xtrinode-observability/templates/lifecycle-dashboard.yaml
+++ b/helm/xtrinode-observability/templates/lifecycle-dashboard.yaml
@@ -1,0 +1,272 @@
+{{- if .Values.dashboards.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-xtrinode-lifecycle-dashboard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: xtrinode-observability
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: dashboard
+{{- with .Values.dashboards.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+data:
+  xtrinode-lifecycle.json: |-
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": "${datasource}",
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (namespace, name) (xtrinode_drain_active)",
+              "legendFormat": "{{`{{namespace}}`}}/{{`{{name}}`}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Active Drains",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${datasource}",
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum by (le, result) (rate(xtrinode_drain_duration_seconds_bucket[5m])))",
+              "legendFormat": "p95 {{`{{result}}`}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Drain Duration p95",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${datasource}",
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.01
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (reason) (rate(xtrinode_drain_failures_total[5m]))",
+              "legendFormat": "{{`{{reason}}`}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Drain Failure Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${datasource}",
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.01
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum by (key_type) (rate(xtrinode_api_k8s_lease_acquired_total[5m]))",
+              "legendFormat": "acquired {{`{{key_type}}`}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum by (key_type) (rate(xtrinode_api_k8s_lease_gated_total[5m]))",
+              "legendFormat": "gated {{`{{key_type}}`}}",
+              "refId": "B"
+            },
+            {
+              "expr": "sum by (key_type) (rate(xtrinode_api_k8s_lease_errors_total[5m]))",
+              "legendFormat": "errors {{`{{key_type}}`}}",
+              "refId": "C"
+            }
+          ],
+          "title": "API Server Lease Outcomes",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": [
+        "xtrinode",
+        "lifecycle"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "Prometheus",
+              "value": "Prometheus"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "XTrinode Lifecycle",
+      "uid": "xtrinode-lifecycle",
+      "version": 1,
+      "weekStart": ""
+    }
+{{- end }}

--- a/helm/xtrinode-observability/values.yaml
+++ b/helm/xtrinode-observability/values.yaml
@@ -62,3 +62,8 @@ vector:
   region: unknown
   serviceMonitor:
     enabled: true
+
+dashboards:
+  enabled: true
+  labels:
+    grafana_dashboard: "1"

--- a/helm/xtrinode-operator/templates/deployment.yaml
+++ b/helm/xtrinode-operator/templates/deployment.yaml
@@ -1,5 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
+{{- $operatorLifecycle := .Values.operator.lifecycle | default dict }}
 metadata:
   name: {{ include "xtrinode-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -41,6 +42,8 @@ spec:
         args:
         - --leader-elect
         - --max-concurrent-reconciles={{ .Values.operator.workers | default 3 }}
+        - --gateway-drain-duration={{ $operatorLifecycle.drainDuration | default "5m" }}
+        - --gateway-drain-requeue-interval={{ $operatorLifecycle.drainRequeueInterval | default "30s" }}
         - --webhook-enabled={{ .Values.webhook.enabled }}
         {{- if .Values.webhook.enabled }}
         - --webhook-port={{ .Values.webhook.port }}

--- a/helm/xtrinode-operator/values.yaml
+++ b/helm/xtrinode-operator/values.yaml
@@ -139,5 +139,12 @@ operator:
   gateway:
     baseURL: "http://xtrinode-gateway.xtrinode-gateway.svc.cluster.local:8080"
 
+  # Lifecycle drain configuration
+  lifecycle:
+    # Maximum route-drain window before elapsed-time fallback is allowed.
+    drainDuration: "5m"
+    # Recheck interval while waiting for active Trino queries to drain.
+    drainRequeueInterval: "30s"
+
   # CAPI provider (azure, aws, gcp)
   capiProvider: "azure"

--- a/helm/xtrinode/README.md
+++ b/helm/xtrinode/README.md
@@ -285,7 +285,19 @@ xtrinode-gateway:
 The Gateway can serve an embedded read-only admin UI at `/ui/admin` and a dynamic status API at
 `/ui/admin/api/gateway/status`. This UI shows the Gateway's current routing view, backend
 lifecycle states, auto-suspend metadata, health check state, circuit-breaker state, and route reload
-status. Trino's own web UI is exposed per backend at `/ui/<namespace>/<backend>/`.
+status. The summary includes the number of draining backends, and backend details show the drain
+deadline and remaining fallback time. Trino's own web UI is exposed per backend at
+`/ui/<namespace>/<backend>/`.
+
+The operator's deletion drain timing is configurable through the operator chart values:
+
+```yaml
+xtrinode-operator:
+  operator:
+    lifecycle:
+      drainDuration: "5m"
+      drainRequeueInterval: "30s"
+```
 
 The UI is disabled by default. If it is enabled behind public ingress, the chart requires Gateway
 auth and TLS:

--- a/helm/xtrinode/values.yaml
+++ b/helm/xtrinode/values.yaml
@@ -112,6 +112,11 @@ xtrinode-operator:
     gateway:
       baseURL: "http://xtrinode-gateway.xtrinode-gateway.svc.cluster.local:8080"
 
+    # Lifecycle drain configuration
+    lifecycle:
+      drainDuration: "5m"
+      drainRequeueInterval: "30s"
+
     # CAPI provider (azure, aws, gcp)
     capiProvider: "azure"
 

--- a/tilt/deployments/values/operator.yaml
+++ b/tilt/deployments/values/operator.yaml
@@ -20,6 +20,9 @@ operator:
     address: "http://prometheus.monitoring.svc.cluster.local:9090"
   gateway:
     baseURL: "http://xtrinode-gateway.xtrinode-gateway.svc.cluster.local:8080"
+  lifecycle:
+    drainDuration: "5m"
+    drainRequeueInterval: "30s"
   capiProvider: "gcp"
 
 webhook:

--- a/tilt/e2e/robot/16_namespace_guardrail_contracts.robot
+++ b/tilt/e2e/robot/16_namespace_guardrail_contracts.robot
@@ -12,8 +12,11 @@ ${GUARDRAIL_A}               guardrail-a
 ${GUARDRAIL_B}               guardrail-b
 ${GUARDRAIL_QUOTA}           xtrinode-namespace-quota
 ${GUARDRAIL_LIMITRANGE}      xtrinode-namespace-limits
+${XTRINODE_FINALIZER}        xtrinode.analytics.xtrinode.io/finalizer
+${DRAIN_OBSERVER_FINALIZER}  e2e.xtrinode.io/observe-drain
 ${DRAIN_STARTED_ANNOTATION}  xtrinode.analytics.xtrinode.io/drain-started-at
-${DRAIN_ELAPSED_TIMESTAMP}   2000-01-01T00:00:00Z
+${DRAIN_COMPLETED_ANNOTATION}    xtrinode.analytics.xtrinode.io/drain-completed-at
+${DRAIN_RESULT_ANNOTATION}   xtrinode.analytics.xtrinode.io/drain-result
 
 *** Test Cases ***
 Shared Namespace Guardrails Recalculate Through Deletion Finalizers
@@ -70,16 +73,53 @@ Namespace Guardrail Resource Should Not Exist
 
 Delete Guardrail XTrinode Through Finalizer
     [Arguments]    ${name}
+    Add Guardrail Drain Observation Finalizer    ${name}
     Command Should Succeed    kubectl    delete    xtrinode/${name}    -n    ${GUARDRAIL_NAMESPACE}    --wait=false
-    Wait Until Keyword Succeeds    60s    2s    Guardrail XTrinode Drain Annotation Should Exist    ${name}
-    ${patch}=    Set Variable    {"metadata":{"annotations":{"${DRAIN_STARTED_ANNOTATION}":"${DRAIN_ELAPSED_TIMESTAMP}"}}}
-    Command Should Succeed    kubectl    patch    xtrinode/${name}    -n    ${GUARDRAIL_NAMESPACE}    --type=merge    -p    ${patch}
+    Wait Until Keyword Succeeds    60s    2s    Guardrail XTrinode Annotation Should Exist    ${name}    ${DRAIN_STARTED_ANNOTATION}
+    Wait Until Keyword Succeeds    180s    2s    Guardrail XTrinode Drain Completion Should Match    ${name}    query_complete
+    Wait Until Keyword Succeeds    180s    2s    Guardrail XTrinode Operator Finalizer Should Be Removed    ${name}
+    Remove Guardrail Drain Observation Finalizer    ${name}
     Command Should Succeed    kubectl    wait    xtrinode/${name}    -n    ${GUARDRAIL_NAMESPACE}    --for=delete    --timeout=180s
 
-Guardrail XTrinode Drain Annotation Should Exist
+Add Guardrail Drain Observation Finalizer
     [Arguments]    ${name}
-    ${annotation}=    Kubectl Output    get    xtrinode/${name}    -n    ${GUARDRAIL_NAMESPACE}    -o    jsonpath={.metadata.annotations.xtrinode\\.analytics\\.xtrinode\\.io/drain-started-at}
-    Should Not Be Empty    ${annotation}
+    Wait Until Keyword Succeeds    60s    2s    Guardrail XTrinode Operator Finalizer Should Exist    ${name}
+    ${patch}=    Set Variable    [{"op":"add","path":"/metadata/finalizers/-","value":"${DRAIN_OBSERVER_FINALIZER}"}]
+    Command Should Succeed    kubectl    patch    xtrinode/${name}    -n    ${GUARDRAIL_NAMESPACE}    --type=json    -p    ${patch}
+
+Remove Guardrail Drain Observation Finalizer
+    [Arguments]    ${name}
+    Command Should Succeed    kubectl    patch    xtrinode/${name}    -n    ${GUARDRAIL_NAMESPACE}    --type=merge    -p    {"metadata":{"finalizers":[]}}
+
+Guardrail XTrinode Operator Finalizer Should Exist
+    [Arguments]    ${name}
+    ${finalizers}=    Kubectl Output    get    xtrinode/${name}    -n    ${GUARDRAIL_NAMESPACE}    -o    jsonpath={.metadata.finalizers}
+    Should Contain    ${finalizers}    ${XTRINODE_FINALIZER}
+
+Guardrail XTrinode Operator Finalizer Should Be Removed
+    [Arguments]    ${name}
+    ${finalizers}=    Kubectl Output    get    xtrinode/${name}    -n    ${GUARDRAIL_NAMESPACE}    -o    jsonpath={.metadata.finalizers}
+    Should Not Contain    ${finalizers}    ${XTRINODE_FINALIZER}
+    Should Contain    ${finalizers}    ${DRAIN_OBSERVER_FINALIZER}
+
+Guardrail XTrinode Annotation Value
+    [Arguments]    ${name}    ${annotation}
+    ${output_format}=    Set Variable    go-template={{ with index .metadata.annotations "${annotation}" }}{{ . }}{{ end }}
+    ${value}=    Kubectl Output    get    xtrinode/${name}    -n    ${GUARDRAIL_NAMESPACE}    -o    ${output_format}
+    RETURN    ${value}
+
+Guardrail XTrinode Annotation Should Exist
+    [Arguments]    ${name}    ${annotation}
+    ${value}=    Guardrail XTrinode Annotation Value    ${name}    ${annotation}
+    Should Not Be Empty    ${value}
+
+Guardrail XTrinode Drain Completion Should Match
+    [Arguments]    ${name}    ${expected_result}
+    ${completed_at}=    Guardrail XTrinode Annotation Value    ${name}    ${DRAIN_COMPLETED_ANNOTATION}
+    Should Not Be Empty    ${completed_at}
+    Should Match Regexp    ${completed_at}    ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:[0-9]{2})$
+    ${result}=    Guardrail XTrinode Annotation Value    ${name}    ${DRAIN_RESULT_ANNOTATION}
+    Should Be Equal    ${result}    ${expected_result}
 
 Cleanup Namespace Guardrail Contract Objects
     Run Command Allow Failure    kubectl    patch    xtrinode/${GUARDRAIL_A}    -n    ${GUARDRAIL_NAMESPACE}    --type=merge    -p    {"metadata":{"finalizers":[]}}

--- a/xtrinode/cmd/operator/main.go
+++ b/xtrinode/cmd/operator/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -47,6 +48,8 @@ type operatorOptions struct {
 	showVersion                    bool
 	maxConcurrentReconciles        int
 	maxConcurrentReconcilesCatalog int
+	gatewayDrainDuration           time.Duration
+	gatewayDrainRequeueInterval    time.Duration
 	webhookEnabled                 bool
 	webhookPort                    int
 	webhookCertDir                 string
@@ -57,6 +60,8 @@ func defaultOperatorOptions() operatorOptions {
 		enableLeaderElection:           config.LeaderElectionEnabled,
 		maxConcurrentReconciles:        config.MaxConcurrentReconciles,
 		maxConcurrentReconcilesCatalog: config.MaxConcurrentReconcilesCatalog,
+		gatewayDrainDuration:           config.GatewayDrainDuration,
+		gatewayDrainRequeueInterval:    config.GatewayDrainRequeueInterval,
 		webhookEnabled:                 true,
 		webhookPort:                    webhook.DefaultPort,
 	}
@@ -76,6 +81,10 @@ func parseOperatorOptions(args []string, output io.Writer) (operatorOptions, zap
 		"Maximum number of concurrent XTrinode reconciliations.")
 	fs.IntVar(&options.maxConcurrentReconcilesCatalog, "max-concurrent-reconciles-catalog", options.maxConcurrentReconcilesCatalog,
 		"Maximum number of concurrent XTrinodeCatalog reconciliations.")
+	fs.DurationVar(&options.gatewayDrainDuration, "gateway-drain-duration", options.gatewayDrainDuration,
+		"Maximum gateway route drain window before elapsed-time fallback is allowed.")
+	fs.DurationVar(&options.gatewayDrainRequeueInterval, "gateway-drain-requeue-interval", options.gatewayDrainRequeueInterval,
+		"Interval for query-aware gateway drain rechecks.")
 	fs.BoolVar(&options.webhookEnabled, "webhook-enabled", options.webhookEnabled,
 		"Enable admission webhooks for XTrinode resources.")
 	fs.IntVar(&options.webhookPort, "webhook-port", options.webhookPort,
@@ -151,7 +160,7 @@ func run() int {
 
 	// Create all service dependencies (injected)
 	nodePoolAdapter := controllers.NewNodePoolAdapter(mgr.GetClient(), setupLog)
-	gatewayService := controllers.NewGatewayService(mgr.GetClient())
+	gatewayService := controllers.NewGatewayServiceWithDrainDuration(mgr.GetClient(), options.gatewayDrainDuration)
 	kedaService := controllers.NewKEDAService(mgr.GetClient(), mgr.GetScheme())
 	catalogService := controllers.NewCatalogService(mgr.GetClient())
 	trinoResourcesService := controllers.NewTrinoResourcesService(mgr.GetClient(), mgr.GetScheme(), version)
@@ -175,6 +184,8 @@ func run() int {
 		AutosuspendService:      autosuspendService,
 		GracefulShutdownService: gracefulShutdownService,
 		OperatorVersion:         version,
+		DrainDuration:           options.gatewayDrainDuration,
+		DrainRequeueInterval:    options.gatewayDrainRequeueInterval,
 	}
 
 	setupLog.Info("Controller initialized",
@@ -182,6 +193,8 @@ func run() int {
 		"leaderElectionNamespace", operatorNamespace,
 		"maxConcurrentReconciles", options.maxConcurrentReconciles,
 		"maxConcurrentReconcilesCatalog", options.maxConcurrentReconcilesCatalog,
+		"gatewayDrainDuration", options.gatewayDrainDuration,
+		"gatewayDrainRequeueInterval", options.gatewayDrainRequeueInterval,
 		"webhookEnabled", options.webhookEnabled,
 		"webhookPort", options.webhookPort,
 		"webhookCertDir", options.webhookCertDir,

--- a/xtrinode/cmd/operator/main_test.go
+++ b/xtrinode/cmd/operator/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -14,6 +15,8 @@ func TestParseOperatorOptions_ParsesRuntimeConfig(t *testing.T) {
 		"--leader-elect=false",
 		"--max-concurrent-reconciles=7",
 		"--max-concurrent-reconciles-catalog=4",
+		"--gateway-drain-duration=7m",
+		"--gateway-drain-requeue-interval=11s",
 		"--webhook-enabled=false",
 		"--webhook-port=9444",
 		"--webhook-cert-dir=/tmp/webhook",
@@ -23,6 +26,8 @@ func TestParseOperatorOptions_ParsesRuntimeConfig(t *testing.T) {
 	require.False(t, options.enableLeaderElection)
 	require.Equal(t, 7, options.maxConcurrentReconciles)
 	require.Equal(t, 4, options.maxConcurrentReconcilesCatalog)
+	require.Equal(t, 7*time.Minute, options.gatewayDrainDuration)
+	require.Equal(t, 11*time.Second, options.gatewayDrainRequeueInterval)
 	require.False(t, options.webhookEnabled)
 	require.Equal(t, 9444, options.webhookPort)
 	require.Equal(t, "/tmp/webhook", options.webhookCertDir)

--- a/xtrinode/controllers/finalizer_regression_test.go
+++ b/xtrinode/controllers/finalizer_regression_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	analyticsv1 "github.com/xtrinode/xtrinode/api/v1"
+	"github.com/xtrinode/xtrinode/internal/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -80,7 +81,7 @@ func TestFinalize_DrainFailureDoesNotMarkDrainStarted(t *testing.T) {
 
 	var updated analyticsv1.XTrinode
 	require.NoError(t, cli.Get(ctx, key, &updated))
-	assert.Empty(t, updated.Annotations["xtrinode.analytics.xtrinode.io/drain-started-at"])
+	assert.Empty(t, updated.Annotations[config.DrainStartedAtAnnotation])
 	assert.Contains(t, updated.Finalizers, FinalizerName)
 }
 
@@ -94,7 +95,7 @@ func TestFinalize_DeregisterFailureKeepsFinalizer(t *testing.T) {
 			Namespace:  key.Namespace,
 			Finalizers: []string{FinalizerName},
 			Annotations: map[string]string{
-				"xtrinode.analytics.xtrinode.io/drain-started-at": time.Now().Add(-6 * time.Minute).Format(time.RFC3339),
+				config.DrainStartedAtAnnotation: time.Now().Add(-6 * time.Minute).Format(time.RFC3339),
 			},
 		},
 		Spec: analyticsv1.XTrinodeSpec{
@@ -119,4 +120,253 @@ func TestFinalize_DeregisterFailureKeepsFinalizer(t *testing.T) {
 	var updated analyticsv1.XTrinode
 	require.NoError(t, cli.Get(ctx, key, &updated))
 	assert.Contains(t, updated.Finalizers, FinalizerName)
+}
+
+func TestFinalize_DrainCompletionAnnotationDoesNotSkipQueryRecheck(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme()
+	key := types.NamespacedName{Name: "runtime", Namespace: "team-a"}
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       key.Name,
+			Namespace:  key.Namespace,
+			Finalizers: []string{FinalizerName},
+			Annotations: map[string]string{
+				config.DrainStartedAtAnnotation:   time.Now().Add(-time.Minute).Format(time.RFC3339),
+				config.DrainCompletedAtAnnotation: time.Now().Format(time.RFC3339),
+				config.DrainResultAnnotation:      "query_complete",
+			},
+		},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size: "s",
+		},
+	}
+	cli := newTestClient(scheme, xtrinode)
+	gateway := &gatewayServiceTestDouble{}
+	graceful := &gracefulShutdownServiceTestDouble{checkErr: errors.New("coordinator query endpoint unavailable")}
+	reconciler := newTestReconciler(cli, scheme)
+	reconciler.GatewayService = gateway
+	reconciler.GracefulShutdownService = graceful
+
+	result, err := reconciler.finalize(ctx, xtrinode)
+	require.NoError(t, err)
+	assert.Equal(t, config.GatewayDrainRequeueInterval, result.RequeueAfter)
+	assert.Equal(t, 1, graceful.checkCalls)
+	assert.Equal(t, 0, graceful.waitCalls)
+	assert.Equal(t, 0, gateway.deregisterCalls)
+
+	var updated analyticsv1.XTrinode
+	require.NoError(t, cli.Get(ctx, key, &updated))
+	assertDrainCompletionAnnotations(t, &updated, "query_complete")
+	assert.Contains(t, updated.Finalizers, FinalizerName)
+}
+
+func TestFinalize_QueryAwareDrainCompletesBeforeFallbackWindow(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme()
+	key := types.NamespacedName{Name: "runtime", Namespace: "team-a"}
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       key.Name,
+			Namespace:  key.Namespace,
+			Finalizers: []string{FinalizerName},
+			Annotations: map[string]string{
+				config.DrainStartedAtAnnotation: time.Now().Add(-time.Minute).Format(time.RFC3339),
+			},
+		},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size: "s",
+		},
+	}
+	cli := newTestClient(scheme, xtrinode)
+	gateway := &gatewayServiceTestDouble{}
+	graceful := &gracefulShutdownServiceTestDouble{safeToScaleDown: true}
+	reconciler := newTestReconciler(cli, scheme)
+	reconciler.GatewayService = gateway
+	reconciler.GracefulShutdownService = graceful
+
+	result, err := reconciler.finalize(ctx, xtrinode)
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+	assert.Equal(t, 0, gateway.drainCalls)
+	assert.Equal(t, 1, gateway.deregisterCalls)
+	assert.Equal(t, 1, graceful.checkCalls)
+	assert.Equal(t, 1, graceful.waitCalls)
+
+	var updated analyticsv1.XTrinode
+	require.NoError(t, cli.Get(ctx, key, &updated))
+	assertDrainCompletionAnnotations(t, &updated, "query_complete")
+	assert.NotContains(t, updated.Finalizers, FinalizerName)
+}
+
+func TestFinalize_QueryAwareDrainWaitsForActiveQueries(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme()
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "runtime",
+			Namespace:  "team-a",
+			Finalizers: []string{FinalizerName},
+			Annotations: map[string]string{
+				config.DrainStartedAtAnnotation: time.Now().Add(-time.Minute).Format(time.RFC3339),
+			},
+		},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size: "s",
+		},
+	}
+	cli := newTestClient(scheme, xtrinode)
+	gateway := &gatewayServiceTestDouble{}
+	graceful := &gracefulShutdownServiceTestDouble{safeToScaleDown: false}
+	reconciler := newTestReconciler(cli, scheme)
+	reconciler.GatewayService = gateway
+	reconciler.GracefulShutdownService = graceful
+
+	result, err := reconciler.finalize(ctx, xtrinode)
+	require.NoError(t, err)
+	assert.Equal(t, config.GatewayDrainRequeueInterval, result.RequeueAfter)
+	assert.Equal(t, 0, gateway.deregisterCalls)
+	assert.Equal(t, 1, graceful.checkCalls)
+	assert.Equal(t, 0, graceful.waitCalls)
+}
+
+func TestFinalize_DrainCompletionNotFoundIsTreatedAsAlreadyFinalized(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme()
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "runtime",
+			Namespace:  "team-a",
+			Finalizers: []string{FinalizerName},
+			Annotations: map[string]string{
+				config.DrainStartedAtAnnotation: time.Now().Add(-time.Minute).Format(time.RFC3339),
+			},
+		},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size: "s",
+		},
+	}
+	cli := newTestClient(scheme)
+	gateway := &gatewayServiceTestDouble{}
+	graceful := &gracefulShutdownServiceTestDouble{safeToScaleDown: true}
+	reconciler := newTestReconciler(cli, scheme)
+	reconciler.GatewayService = gateway
+	reconciler.GracefulShutdownService = graceful
+
+	result, err := reconciler.finalize(ctx, xtrinode)
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+	assert.Equal(t, 0, gateway.deregisterCalls)
+	assert.Equal(t, 1, graceful.checkCalls)
+	assert.Equal(t, 0, graceful.waitCalls)
+}
+
+func TestFinalize_QueryCheckErrorUsesTimeFallbackAfterDrainWindow(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme()
+	key := types.NamespacedName{Name: "runtime", Namespace: "team-a"}
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       key.Name,
+			Namespace:  key.Namespace,
+			Finalizers: []string{FinalizerName},
+			Annotations: map[string]string{
+				config.DrainStartedAtAnnotation: time.Now().Add(-config.GatewayDrainDuration - time.Minute).Format(time.RFC3339),
+			},
+		},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size: "s",
+		},
+	}
+	cli := newTestClient(scheme, xtrinode)
+	gateway := &gatewayServiceTestDouble{}
+	graceful := &gracefulShutdownServiceTestDouble{checkErr: errors.New("coordinator query endpoint unavailable")}
+	reconciler := newTestReconciler(cli, scheme)
+	reconciler.GatewayService = gateway
+	reconciler.GracefulShutdownService = graceful
+
+	result, err := reconciler.finalize(ctx, xtrinode)
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+	assert.Equal(t, 1, gateway.deregisterCalls)
+	assert.Equal(t, 1, graceful.checkCalls)
+	assert.Equal(t, 1, graceful.waitCalls)
+
+	var updated analyticsv1.XTrinode
+	require.NoError(t, cli.Get(ctx, key, &updated))
+	assertDrainCompletionAnnotations(t, &updated, "time_fallback")
+}
+
+func TestFinalize_QueryCheckErrorWaitsBeforeFallbackWindow(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme()
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "runtime",
+			Namespace:  "team-a",
+			Finalizers: []string{FinalizerName},
+			Annotations: map[string]string{
+				config.DrainStartedAtAnnotation: time.Now().Add(-time.Minute).Format(time.RFC3339),
+			},
+		},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size: "s",
+		},
+	}
+	cli := newTestClient(scheme, xtrinode)
+	gateway := &gatewayServiceTestDouble{}
+	graceful := &gracefulShutdownServiceTestDouble{checkErr: errors.New("coordinator query endpoint unavailable")}
+	reconciler := newTestReconciler(cli, scheme)
+	reconciler.GatewayService = gateway
+	reconciler.GracefulShutdownService = graceful
+
+	result, err := reconciler.finalize(ctx, xtrinode)
+	require.NoError(t, err)
+	assert.Equal(t, config.GatewayDrainRequeueInterval, result.RequeueAfter)
+	assert.Equal(t, 0, gateway.deregisterCalls)
+	assert.Equal(t, 1, graceful.checkCalls)
+	assert.Equal(t, 0, graceful.waitCalls)
+}
+
+func assertDrainCompletionAnnotations(t *testing.T, xtrinode *analyticsv1.XTrinode, expectedResult string) {
+	t.Helper()
+	require.NotNil(t, xtrinode.Annotations)
+	completedAt := xtrinode.Annotations[config.DrainCompletedAtAnnotation]
+	require.NotEmpty(t, completedAt)
+	_, err := time.Parse(time.RFC3339, completedAt)
+	require.NoError(t, err)
+	assert.Equal(t, expectedResult, xtrinode.Annotations[config.DrainResultAnnotation])
+}
+
+func TestFinalize_QueryCheckErrorUsesCustomDrainWindow(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme()
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "runtime",
+			Namespace:  "team-a",
+			Finalizers: []string{FinalizerName},
+			Annotations: map[string]string{
+				config.DrainStartedAtAnnotation: time.Now().Add(-6 * time.Minute).Format(time.RFC3339),
+			},
+		},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size: "s",
+		},
+	}
+	cli := newTestClient(scheme, xtrinode)
+	gateway := &gatewayServiceTestDouble{}
+	graceful := &gracefulShutdownServiceTestDouble{checkErr: errors.New("coordinator query endpoint unavailable")}
+	reconciler := newTestReconciler(cli, scheme)
+	reconciler.GatewayService = gateway
+	reconciler.GracefulShutdownService = graceful
+	reconciler.DrainDuration = 10 * time.Minute
+	reconciler.DrainRequeueInterval = 7 * time.Second
+
+	result, err := reconciler.finalize(ctx, xtrinode)
+	require.NoError(t, err)
+	assert.Equal(t, 7*time.Second, result.RequeueAfter)
+	assert.Equal(t, 0, gateway.deregisterCalls)
+	assert.Equal(t, 1, graceful.checkCalls)
+	assert.Equal(t, 0, graceful.waitCalls)
 }

--- a/xtrinode/controllers/service_implementations.go
+++ b/xtrinode/controllers/service_implementations.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -10,6 +11,7 @@ import (
 	analyticsv1 "github.com/xtrinode/xtrinode/api/v1"
 	"github.com/xtrinode/xtrinode/internal/autosuspend"
 	"github.com/xtrinode/xtrinode/internal/catalog"
+	"github.com/xtrinode/xtrinode/internal/config"
 	"github.com/xtrinode/xtrinode/internal/gracefulshutdown"
 	"github.com/xtrinode/xtrinode/internal/keda"
 	"github.com/xtrinode/xtrinode/internal/trino/resources"
@@ -18,12 +20,21 @@ import (
 
 // GatewayService wraps the gateway package functions
 type GatewayService struct {
-	client client.Client
+	client        client.Client
+	drainDuration time.Duration
 }
 
 // NewGatewayService creates a new GatewayService
 func NewGatewayService(cli client.Client) GatewayServiceInterface {
-	return &GatewayService{client: cli}
+	return NewGatewayServiceWithDrainDuration(cli, config.GatewayDrainDuration)
+}
+
+// NewGatewayServiceWithDrainDuration creates a GatewayService with explicit route-drain timing.
+func NewGatewayServiceWithDrainDuration(cli client.Client, drainDuration time.Duration) GatewayServiceInterface {
+	if drainDuration <= 0 {
+		drainDuration = config.GatewayDrainDuration
+	}
+	return &GatewayService{client: cli, drainDuration: drainDuration}
 }
 
 // RegisterRoute registers a gateway route
@@ -33,7 +44,7 @@ func (g *GatewayService) RegisterRoute(ctx context.Context, xtrinode *analyticsv
 
 // DrainRoute sets a backend to DRAINING state for graceful removal
 func (g *GatewayService) DrainRoute(ctx context.Context, xtrinode *analyticsv1.XTrinode) error {
-	return gateway.DrainRoute(ctx, g.client, xtrinode)
+	return gateway.DrainRouteWithDuration(ctx, g.client, xtrinode, g.drainDuration)
 }
 
 // DeregisterRoute deregisters a gateway route

--- a/xtrinode/controllers/xtrinode_controller.go
+++ b/xtrinode/controllers/xtrinode_controller.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	analyticsv1 "github.com/xtrinode/xtrinode/api/v1"
+	"github.com/xtrinode/xtrinode/internal/config"
 	"github.com/xtrinode/xtrinode/internal/events"
 	"github.com/xtrinode/xtrinode/internal/status"
 	"github.com/xtrinode/xtrinode/pkg/metrics"
@@ -40,6 +41,8 @@ type XTrinodeReconciler struct {
 	AutosuspendService      AutosuspendServiceInterface      // Autosuspend service for auto-suspend logic (injected)
 	GracefulShutdownService GracefulShutdownServiceInterface // Graceful shutdown service for query checks (injected)
 	OperatorVersion         string                           // Operator version for resource revisioning
+	DrainDuration           time.Duration                    // Maximum route-drain fallback window
+	DrainRequeueInterval    time.Duration                    // Interval for query-aware drain rechecks
 }
 
 // +kubebuilder:rbac:groups=analytics.xtrinode.io,resources=xtrinodes,verbs=get;list;watch;create;update;patch;delete
@@ -101,7 +104,7 @@ func (r *XTrinodeReconciler) reconcile(ctx context.Context, req ctrl.Request) (c
 	if xtrinode.DeletionTimestamp != nil {
 		// The drain annotation is set during the first pass of finalize(), so its
 		// absence indicates the first deletion pass.
-		if xtrinode.Annotations == nil || xtrinode.Annotations["xtrinode.analytics.xtrinode.io/drain-started-at"] == "" {
+		if xtrinode.Annotations == nil || xtrinode.Annotations[config.DrainStartedAtAnnotation] == "" {
 			r.EventRecorder.Normal(&xtrinode, events.ReasonDeleted, events.FormatMessage("XTrinode deletion started, finalizing resources"))
 			metrics.XTrinodeDeleted.WithLabelValues(xtrinode.Namespace, xtrinode.Name).Inc()
 		}

--- a/xtrinode/controllers/xtrinode_finalizer.go
+++ b/xtrinode/controllers/xtrinode_finalizer.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -15,6 +16,7 @@ import (
 	"github.com/xtrinode/xtrinode/internal/events"
 	"github.com/xtrinode/xtrinode/internal/external"
 	"github.com/xtrinode/xtrinode/internal/retry"
+	"github.com/xtrinode/xtrinode/pkg/metrics"
 )
 
 // ensureFinalizer ensures the finalizer is present on the XTrinode
@@ -54,7 +56,7 @@ func (r *XTrinodeReconciler) finalize(ctx context.Context, xtrinode *analyticsv1
 	if xtrinode.Annotations == nil {
 		xtrinode.Annotations = make(map[string]string)
 	}
-	drainStartedAt, drainStarted := xtrinode.Annotations["xtrinode.analytics.xtrinode.io/drain-started-at"]
+	drainStartedAt, drainStarted := xtrinode.Annotations[config.DrainStartedAtAnnotation]
 
 	if !drainStarted {
 		// First time in finalizer - initiate drain
@@ -64,6 +66,7 @@ func (r *XTrinodeReconciler) finalize(ctx context.Context, xtrinode *analyticsv1
 		}); err != nil {
 			log.Error(err, "failed to drain gateway route")
 			r.EventRecorder.Warningf(xtrinode, events.ReasonDrainStarted, "Failed to start gateway route drain: %v", err)
+			metrics.XTrinodeDrainFailures.WithLabelValues(xtrinode.Namespace, xtrinode.Name, "route_update_error").Inc()
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, fmt.Errorf("failed to start gateway route drain: %w", err)
 		}
 
@@ -75,48 +78,46 @@ func (r *XTrinodeReconciler) finalize(ctx context.Context, xtrinode *analyticsv1
 				if xtrinode.Annotations == nil {
 					xtrinode.Annotations = make(map[string]string)
 				}
-				xtrinode.Annotations["xtrinode.analytics.xtrinode.io/drain-started-at"] = time.Now().Format(time.RFC3339)
+				xtrinode.Annotations[config.DrainStartedAtAnnotation] = time.Now().Format(time.RFC3339)
 				return r.Update(ctx, xtrinode)
 			},
 		)
 		if err != nil {
 			log.Error(err, "failed to update drain annotation")
+			metrics.XTrinodeDrainFailures.WithLabelValues(xtrinode.Namespace, xtrinode.Name, "annotation_update_error").Inc()
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, err
 		}
+		metrics.XTrinodeDrainActive.WithLabelValues(xtrinode.Namespace, xtrinode.Name).Set(1)
 		log.Info("Backend set to DRAINING, waiting for drain condition", "xtrinode", xtrinode.Name)
-		r.EventRecorder.Normal(xtrinode, events.ReasonDrainStarted, "Gateway route set to DRAINING state, waiting 5 minutes for active connections to complete")
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		r.EventRecorder.Normal(xtrinode, events.ReasonDrainStarted, "Gateway route set to DRAINING state, waiting for active queries to complete")
+		return ctrl.Result{RequeueAfter: r.drainRequeueInterval()}, nil
 	}
 
-	// Wait for the drain period to complete.
-	drainStartTime, err := time.Parse(time.RFC3339, drainStartedAt)
+	metrics.XTrinodeDrainActive.WithLabelValues(xtrinode.Namespace, xtrinode.Name).Set(1)
+	drainComplete, drainResult, drainElapsed := r.queryAwareDrainComplete(ctx, xtrinode, drainStartedAt, log)
+	if !drainComplete {
+		return ctrl.Result{RequeueAfter: r.drainRequeueInterval()}, nil
+	}
+
+	drainMarked, err := r.markDrainComplete(ctx, xtrinode, drainResult, log)
 	if err != nil {
-		log.Error(err, "failed to parse drain start time, proceeding with deletion")
-	} else {
-		elapsed := time.Since(drainStartTime)
-		drainDuration := 5 * time.Minute // Match DrainRoute policy
-		if elapsed < drainDuration {
-			remaining := drainDuration - elapsed
-			log.Info("Drain condition not met, waiting",
+		if k8serrors.IsNotFound(err) {
+			log.Info("XTrinode no longer exists while marking drain completion, treating finalization as complete",
 				"xtrinode", xtrinode.Name,
-				"elapsed", elapsed,
-				"remaining", remaining)
-			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+				"result", drainResult)
+			metrics.XTrinodeDrainActive.WithLabelValues(xtrinode.Namespace, xtrinode.Name).Set(0)
+			return ctrl.Result{}, nil
 		}
+		log.Error(err, "failed to update drain completion annotation")
+		metrics.XTrinodeDrainFailures.WithLabelValues(xtrinode.Namespace, xtrinode.Name, "completion_annotation_update_error").Inc()
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
 	}
-
-	log.Info("Drain condition met, proceeding with deletion", "xtrinode", xtrinode.Name)
-	r.EventRecorder.Normal(xtrinode, events.ReasonDrainCompleted, "Drain period completed, proceeding with resource cleanup")
-
-	// Check if queries are running before deletion.
-	safeToDelete, err := r.GracefulShutdownService.CheckQueriesBeforeScaleDown(ctx, xtrinode, log)
-	if err != nil {
-		log.Error(err, "failed to check queries before deletion")
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
-	}
-	if !safeToDelete {
-		log.Info("Queries still running, waiting before deletion", "xtrinode", xtrinode.Name)
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	if drainMarked {
+		log.Info("Drain condition met, proceeding with deletion", "xtrinode", xtrinode.Name, "result", drainResult, "elapsed", drainElapsed)
+		r.EventRecorder.Normalf(xtrinode, events.ReasonDrainCompleted, "Drain completed via %s, proceeding with resource cleanup", drainResult)
+		metrics.XTrinodeDrainDuration.WithLabelValues(xtrinode.Namespace, xtrinode.Name, drainResult).Observe(drainElapsed.Seconds())
+	} else {
+		log.Info("Drain already marked complete, continuing deletion", "xtrinode", xtrinode.Name, "result", xtrinode.Annotations[config.DrainResultAnnotation])
 	}
 
 	// Wait for pods to terminate gracefully if any are terminating.
@@ -131,6 +132,7 @@ func (r *XTrinodeReconciler) finalize(ctx context.Context, xtrinode *analyticsv1
 		r.EventRecorder.Warningf(xtrinode, events.ReasonCleanupStarted, "Resource cleanup failed: %v", err)
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
+	metrics.XTrinodeDrainActive.WithLabelValues(xtrinode.Namespace, xtrinode.Name).Set(0)
 	r.EventRecorder.Normal(xtrinode, events.ReasonCleanupCompleted, "Resource cleanup completed")
 
 	if err := r.reconcileNamespaceGuardrailsAfterDelete(ctx, xtrinode, log); err != nil {
@@ -148,6 +150,88 @@ func (r *XTrinodeReconciler) finalize(ctx context.Context, xtrinode *analyticsv1
 	r.EventRecorder.Normal(xtrinode, events.ReasonFinalized, events.FormatMessage("XTrinode finalization complete, all resources cleaned up"))
 
 	return ctrl.Result{}, nil
+}
+
+func (r *XTrinodeReconciler) queryAwareDrainComplete(ctx context.Context, xtrinode *analyticsv1.XTrinode, drainStartedAt string, log logr.Logger) (bool, string, time.Duration) {
+	drainDuration := r.drainDuration()
+	drainStartTime, err := time.Parse(time.RFC3339, drainStartedAt)
+	if err != nil {
+		log.Error(err, "failed to parse drain start time, using elapsed drain fallback")
+		metrics.XTrinodeDrainFailures.WithLabelValues(xtrinode.Namespace, xtrinode.Name, "invalid_start_time").Inc()
+		drainStartTime = time.Now().Add(-drainDuration)
+	}
+
+	elapsed := time.Since(drainStartTime)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	fallbackReady := elapsed >= drainDuration
+
+	safeToDelete, checkErr := r.GracefulShutdownService.CheckQueriesBeforeScaleDown(ctx, xtrinode, log)
+	if checkErr != nil {
+		metrics.XTrinodeDrainFailures.WithLabelValues(xtrinode.Namespace, xtrinode.Name, "query_check_error").Inc()
+		if fallbackReady {
+			log.Info("Query-aware drain check failed after fallback window, proceeding by elapsed drain time",
+				"xtrinode", xtrinode.Name,
+				"elapsed", elapsed,
+				"fallbackWindow", drainDuration,
+				"error", checkErr)
+			return true, "time_fallback", elapsed
+		}
+		log.Info("Query-aware drain check failed before fallback window, waiting",
+			"xtrinode", xtrinode.Name,
+			"elapsed", elapsed,
+			"remaining", drainDuration-elapsed,
+			"error", checkErr)
+		return false, "query_check_error", elapsed
+	}
+
+	if safeToDelete {
+		return true, "query_complete", elapsed
+	}
+
+	log.Info("Queries still running, waiting before deletion",
+		"xtrinode", xtrinode.Name,
+		"elapsed", elapsed,
+		"fallbackWindow", drainDuration)
+	return false, "active_queries", elapsed
+}
+
+func (r *XTrinodeReconciler) markDrainComplete(ctx context.Context, xtrinode *analyticsv1.XTrinode, result string, log logr.Logger) (bool, error) {
+	completedAt := time.Now().Format(time.RFC3339)
+	marked := false
+	err := retry.OnConflictWithRefresh(ctx, retry.DefaultConfig(), log,
+		func() error {
+			return r.Get(ctx, client.ObjectKeyFromObject(xtrinode), xtrinode)
+		},
+		func() error {
+			if xtrinode.Annotations == nil {
+				xtrinode.Annotations = make(map[string]string)
+			}
+			if xtrinode.Annotations[config.DrainCompletedAtAnnotation] != "" {
+				return nil
+			}
+			xtrinode.Annotations[config.DrainCompletedAtAnnotation] = completedAt
+			xtrinode.Annotations[config.DrainResultAnnotation] = result
+			marked = true
+			return r.Update(ctx, xtrinode)
+		},
+	)
+	return marked, err
+}
+
+func (r *XTrinodeReconciler) drainDuration() time.Duration {
+	if r.DrainDuration <= 0 {
+		return config.GatewayDrainDuration
+	}
+	return r.DrainDuration
+}
+
+func (r *XTrinodeReconciler) drainRequeueInterval() time.Duration {
+	if r.DrainRequeueInterval <= 0 {
+		return config.GatewayDrainRequeueInterval
+	}
+	return r.DrainRequeueInterval
 }
 
 // cleanupResources cleans up all XTrinode resources.

--- a/xtrinode/controllers/xtrinode_finalizer.go
+++ b/xtrinode/controllers/xtrinode_finalizer.go
@@ -152,7 +152,7 @@ func (r *XTrinodeReconciler) finalize(ctx context.Context, xtrinode *analyticsv1
 	return ctrl.Result{}, nil
 }
 
-func (r *XTrinodeReconciler) queryAwareDrainComplete(ctx context.Context, xtrinode *analyticsv1.XTrinode, drainStartedAt string, log logr.Logger) (bool, string, time.Duration) {
+func (r *XTrinodeReconciler) queryAwareDrainComplete(ctx context.Context, xtrinode *analyticsv1.XTrinode, drainStartedAt string, log logr.Logger) (complete bool, result string, elapsed time.Duration) {
 	drainDuration := r.drainDuration()
 	drainStartTime, err := time.Parse(time.RFC3339, drainStartedAt)
 	if err != nil {
@@ -161,7 +161,7 @@ func (r *XTrinodeReconciler) queryAwareDrainComplete(ctx context.Context, xtrino
 		drainStartTime = time.Now().Add(-drainDuration)
 	}
 
-	elapsed := time.Since(drainStartTime)
+	elapsed = time.Since(drainStartTime)
 	if elapsed < 0 {
 		elapsed = 0
 	}

--- a/xtrinode/internal/config/config.go
+++ b/xtrinode/internal/config/config.go
@@ -166,6 +166,13 @@ const (
 	// before marking an XTrinode Ready and exposing it as RUNNING through the gateway.
 	RuntimeReadinessRequeueInterval = 5 * time.Second
 
+	// GatewayDrainDuration is the maximum route-drain window used as a fallback
+	// when query-aware drain completion cannot be verified from the coordinator.
+	GatewayDrainDuration = 5 * time.Minute
+
+	// GatewayDrainRequeueInterval is how often the operator rechecks route drain completion.
+	GatewayDrainRequeueInterval = 30 * time.Second
+
 	// Redis sticky routing configuration
 	// GatewayRedisEnabled enables Redis for distributed sticky routing
 	GatewayRedisEnabled = false
@@ -501,6 +508,15 @@ const (
 
 	// SuspendLeaseUntilAnnotation stores RFC3339 timestamp until which suspend operation is leased
 	SuspendLeaseUntilAnnotation = "xtrinode.analytics.xtrinode.io/suspend-lease-until"
+
+	// DrainStartedAtAnnotation stores when a gateway route drain started during finalization.
+	DrainStartedAtAnnotation = "xtrinode.analytics.xtrinode.io/drain-started-at"
+
+	// DrainCompletedAtAnnotation stores when query-aware drain completion was observed.
+	DrainCompletedAtAnnotation = "xtrinode.analytics.xtrinode.io/drain-completed-at"
+
+	// DrainResultAnnotation stores the completion path for the deletion drain.
+	DrainResultAnnotation = "xtrinode.analytics.xtrinode.io/drain-result"
 )
 
 // LabelKeys defines label keys used for resource organization

--- a/xtrinode/internal/config/config_test.go
+++ b/xtrinode/internal/config/config_test.go
@@ -278,6 +278,21 @@ func TestConstants(t *testing.T) {
 	if GatewayAPIServerTimeout != 5*time.Second {
 		t.Errorf("Expected GatewayAPIServerTimeout to be 5s, got %v", GatewayAPIServerTimeout)
 	}
+	if GatewayDrainDuration != 5*time.Minute {
+		t.Errorf("Expected GatewayDrainDuration to be 5m, got %v", GatewayDrainDuration)
+	}
+	if GatewayDrainRequeueInterval != 30*time.Second {
+		t.Errorf("Expected GatewayDrainRequeueInterval to be 30s, got %v", GatewayDrainRequeueInterval)
+	}
+	if DrainStartedAtAnnotation != "xtrinode.analytics.xtrinode.io/drain-started-at" {
+		t.Errorf("Expected DrainStartedAtAnnotation to be xtrinode analytics key, got %s", DrainStartedAtAnnotation)
+	}
+	if DrainCompletedAtAnnotation != "xtrinode.analytics.xtrinode.io/drain-completed-at" {
+		t.Errorf("Expected DrainCompletedAtAnnotation to be xtrinode analytics key, got %s", DrainCompletedAtAnnotation)
+	}
+	if DrainResultAnnotation != "xtrinode.analytics.xtrinode.io/drain-result" {
+		t.Errorf("Expected DrainResultAnnotation to be xtrinode analytics key, got %s", DrainResultAnnotation)
+	}
 
 	// Test HTTP paths
 	if HealthPath != "/health" {

--- a/xtrinode/pkg/api-server/metrics.go
+++ b/xtrinode/pkg/api-server/metrics.go
@@ -58,7 +58,7 @@ var (
 			Name: "xtrinode_api_k8s_lease_acquired_total",
 			Help: "Total number of K8s Lease acquisitions by key type",
 		},
-		[]string{"key_type"}, // runtime, pool
+		[]string{"key_type"}, // runtime, pool, suspend
 	)
 
 	// k8sLeaseGatedTotal tracks requests gated by K8s Lease
@@ -67,7 +67,16 @@ var (
 			Name: "xtrinode_api_k8s_lease_gated_total",
 			Help: "Total number of requests gated by active K8s Lease",
 		},
-		[]string{"key_type"}, // runtime, pool
+		[]string{"key_type"}, // runtime, pool, suspend
+	)
+
+	// k8sLeaseErrorsTotal tracks K8s Lease acquisition errors
+	k8sLeaseErrorsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "xtrinode_api_k8s_lease_errors_total",
+			Help: "Total number of K8s Lease errors by key type",
+		},
+		[]string{"key_type"}, // runtime, pool, suspend
 	)
 )
 
@@ -104,4 +113,9 @@ func recordK8sLeaseAcquired(keyType string) {
 // recordK8sLeaseGated records a request gated by K8s Lease
 func recordK8sLeaseGated(keyType string) {
 	k8sLeaseGatedTotal.WithLabelValues(keyType).Inc()
+}
+
+// recordK8sLeaseError records a K8s Lease acquisition error
+func recordK8sLeaseError(keyType string) {
+	k8sLeaseErrorsTotal.WithLabelValues(keyType).Inc()
 }

--- a/xtrinode/pkg/api-server/resume.go
+++ b/xtrinode/pkg/api-server/resume.go
@@ -132,6 +132,7 @@ func (s *Server) handleUnifiedResume(w http.ResponseWriter, r *http.Request) {
 	leaseResult, err := s.leaseManager.AcquireLease(r.Context(), key, keyType)
 	if err != nil {
 		result = "error"
+		recordK8sLeaseError(string(keyType))
 		s.log.Error(err, "Failed to acquire lease", "key", key, "keyType", keyType)
 		s.writeError(w, http.StatusInternalServerError, "Failed to acquire lease", "LEASE_ERROR")
 		return
@@ -155,6 +156,7 @@ func (s *Server) tryPoolGate(w http.ResponseWriter, r *http.Request, routingGrou
 	// Try acquire pool lease FIRST (before expensive checks)
 	leaseResult, err := s.leaseManager.AcquireLease(r.Context(), key, keyType)
 	if err != nil {
+		recordK8sLeaseError(string(keyType))
 		s.log.Error(err, "Failed to acquire pool lease", "key", key)
 		s.writeError(w, http.StatusInternalServerError, "Failed to acquire lease", "LEASE_ERROR")
 		return true, "error"

--- a/xtrinode/pkg/api-server/server.go
+++ b/xtrinode/pkg/api-server/server.go
@@ -487,6 +487,7 @@ func (s *Server) resumeRuntime(w http.ResponseWriter, r *http.Request, namespace
 	if err != nil {
 		result = "error"
 		recordResumeRequest(result)
+		recordK8sLeaseError(string(keyType))
 		s.log.Error(err, "Failed to acquire lease", "namespace", namespace, "name", name, "key", key)
 		s.writeError(w, http.StatusInternalServerError, "Failed to acquire lease", "LEASE_ERROR")
 		return
@@ -631,6 +632,7 @@ func (s *Server) suspendRuntime(w http.ResponseWriter, r *http.Request, namespac
 	if err != nil {
 		result = "error"
 		recordSuspendRequest(result)
+		recordK8sLeaseError(string(keyType))
 		s.log.Error(err, "Failed to acquire lease", "namespace", namespace, "name", name, "key", key)
 		s.writeError(w, http.StatusInternalServerError, "Failed to acquire lease", "LEASE_ERROR")
 		return

--- a/xtrinode/pkg/gateway/gateway.go
+++ b/xtrinode/pkg/gateway/gateway.go
@@ -193,10 +193,14 @@ func RegisterRoute(ctx context.Context, cli client.Client, xtrinode *analyticsv1
 //
 // Drain policy:
 // - Sets State = DRAINING
-// - Sets DrainUntil = now + 5 minutes (configurable)
+// - Sets DrainUntil = now + configured drain duration
 // - Gateway will reject NEW queries but allow sticky queries
 // - Operator should wait for drain condition before calling DeregisterRoute
 func DrainRoute(ctx context.Context, cli client.Client, xtrinode *analyticsv1.XTrinode) error {
+	return DrainRouteWithDuration(ctx, cli, xtrinode, config.GatewayDrainDuration)
+}
+
+func DrainRouteWithDuration(ctx context.Context, cli client.Client, xtrinode *analyticsv1.XTrinode, drainDuration time.Duration) error {
 	// Get the gateway ConfigMap (read-only, don't create if missing)
 	configMap, err := getConfigMap(ctx, cli, GatewayConfigMapName, GatewayConfigMapNamespace)
 	if err != nil {
@@ -222,7 +226,7 @@ func DrainRoute(ctx context.Context, cli client.Client, xtrinode *analyticsv1.XT
 				return fmt.Errorf("cannot update routes due to parse error: %w", err)
 			}
 			// Set backend to DRAINING state with drain timestamp anywhere it exists.
-			routes, changed := setBackendDrainingAllRoutes(routes, xtrinode.Name, xtrinode.Namespace)
+			routes, changed := setBackendDrainingAllRoutes(routes, xtrinode.Name, xtrinode.Namespace, drainDuration)
 			if !changed {
 				return nil
 			}
@@ -341,8 +345,11 @@ func computeBackendState(xtrinode *analyticsv1.XTrinode) BackendState {
 	}
 }
 
-func setBackendDrainingAllRoutes(routes []RouteEntry, backendName, backendNamespace string) ([]RouteEntry, bool) {
-	drainUntil := time.Now().Add(5 * time.Minute).Format(time.RFC3339)
+func setBackendDrainingAllRoutes(routes []RouteEntry, backendName, backendNamespace string, drainDuration time.Duration) ([]RouteEntry, bool) {
+	if drainDuration <= 0 {
+		drainDuration = config.GatewayDrainDuration
+	}
+	drainUntil := time.Now().Add(drainDuration).Format(time.RFC3339)
 	changed := false
 	for i := range routes {
 		for j := range routes[i].Backends {

--- a/xtrinode/pkg/gateway/regression_test.go
+++ b/xtrinode/pkg/gateway/regression_test.go
@@ -504,6 +504,37 @@ func TestDrainRoute_WithExistingConfigMap(t *testing.T) {
 	require.False(t, routes[0].Backends[0].Active)
 }
 
+func TestDrainRouteWithDuration_UsesConfiguredDrainUntil(t *testing.T) {
+	ctx := context.Background()
+	cli := fake.NewClientBuilder().Build()
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-runtime",
+			Namespace: "default",
+		},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size:    "m",
+			Routing: &analyticsv1.RoutingSpec{RoutingGroup: "test-runtime"},
+		},
+	}
+	require.NoError(t, RegisterRoute(ctx, cli, xtrinode))
+
+	beforeDrain := time.Now()
+	require.NoError(t, DrainRouteWithDuration(ctx, cli, xtrinode, 2*time.Minute))
+
+	configMap := &corev1.ConfigMap{}
+	key := client.ObjectKey{Name: GatewayConfigMapName, Namespace: GatewayConfigMapNamespace}
+	require.NoError(t, cli.Get(ctx, key, configMap))
+	routes, err := parseRoutes(configMap.Data[GatewayConfigMapKey])
+	require.NoError(t, err)
+	require.Len(t, routes, 1)
+	require.Len(t, routes[0].Backends, 1)
+
+	drainUntil, err := time.Parse(time.RFC3339, routes[0].Backends[0].DrainUntil)
+	require.NoError(t, err)
+	require.WithinDuration(t, beforeDrain.Add(2*time.Minute), drainUntil, 2*time.Second)
+}
+
 func TestParseRoutes_DefaultsOmittedActiveToTrue(t *testing.T) {
 	routes, err := parseRoutes(`
 routes:

--- a/xtrinode/pkg/gateway/ui/static/app.css
+++ b/xtrinode/pkg/gateway/ui/static/app.css
@@ -104,7 +104,7 @@ h1 {
 
 .summary {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 12px;
 }
 

--- a/xtrinode/pkg/gateway/ui/static/app.js
+++ b/xtrinode/pkg/gateway/ui/static/app.js
@@ -32,6 +32,7 @@ const elements = {
     routes: document.getElementById("metric-routes"),
     backends: document.getElementById("metric-backends"),
     running: document.getElementById("metric-running"),
+    draining: document.getElementById("metric-draining"),
     paused: document.getElementById("metric-paused"),
     unhealthy: document.getElementById("metric-unhealthy"),
     circuits: document.getElementById("metric-circuits")
@@ -71,6 +72,7 @@ function render() {
   elements.metrics.routes.textContent = summary.routes || 0;
   elements.metrics.backends.textContent = summary.backends || 0;
   elements.metrics.running.textContent = summary.runningBackends || 0;
+  elements.metrics.draining.textContent = summary.drainingBackends || 0;
   elements.metrics.paused.textContent = summary.pausedBackends || 0;
   elements.metrics.unhealthy.textContent = (summary.unhealthyBackends || 0) + (summary.sleepingBackends || 0);
   elements.metrics.circuits.textContent = summary.openCircuitBackends || 0;
@@ -196,7 +198,8 @@ function renderDrawer(row) {
     ["Selectable for new queries", selectabilityLabel(backend)],
     ["Tier", backend.tier || "not set"],
     ["Capacity units", backend.capacityUnits || "not set"],
-    ["Drain until", backend.drainUntil || "not set"]
+    ["Drain until", formatOptionalDrainUntil(backend.drainUntil)],
+    ["Drain ETA", formatDrainEta(backend.drainUntil)]
   ]);
   renderFieldList(elements.drawerLifecycle, [
     ["Auto suspend after", lifecycle.autoSuspendAfter || "not set"],
@@ -514,6 +517,10 @@ function formatOptionalDate(value) {
   return value ? formatDate(value) : "never";
 }
 
+function formatOptionalDrainUntil(value) {
+  return value ? formatDate(value) : "not set";
+}
+
 function formatSuspendEta(value) {
   if (!value) return "not scheduled";
   const suspendAt = new Date(value);
@@ -522,6 +529,16 @@ function formatSuspendEta(value) {
   if (!Number.isFinite(remainingMillis)) return formatDate(value);
   if (remainingMillis <= 0) return `${formatDate(value)} (due)`;
   return `${formatDate(value)} (${formatDuration(remainingMillis)} remaining)`;
+}
+
+function formatDrainEta(value) {
+  if (!value) return "not draining";
+  const drainUntil = new Date(value);
+  const generatedAt = state.data?.generatedAt ? new Date(state.data.generatedAt) : new Date();
+  const remainingMillis = drainUntil.getTime() - generatedAt.getTime();
+  if (!Number.isFinite(remainingMillis)) return formatDate(value);
+  if (remainingMillis <= 0) return "fallback window elapsed";
+  return `${formatDuration(remainingMillis)} remaining`;
 }
 
 function formatDuration(milliseconds) {

--- a/xtrinode/pkg/gateway/ui/static/index.html
+++ b/xtrinode/pkg/gateway/ui/static/index.html
@@ -23,6 +23,7 @@
         <div class="metric"><div class="metric-label">Routes</div><div class="metric-value" id="metric-routes">0</div></div>
         <div class="metric"><div class="metric-label">Backends</div><div class="metric-value" id="metric-backends">0</div></div>
         <div class="metric"><div class="metric-label">Running</div><div class="metric-value" id="metric-running">0</div></div>
+        <div class="metric"><div class="metric-label">Draining</div><div class="metric-value" id="metric-draining">0</div></div>
         <div class="metric"><div class="metric-label">Paused</div><div class="metric-value" id="metric-paused">0</div></div>
         <div class="metric"><div class="metric-label">Unhealthy</div><div class="metric-value" id="metric-unhealthy">0</div></div>
         <div class="metric"><div class="metric-label">Open circuits</div><div class="metric-value" id="metric-circuits">0</div></div>

--- a/xtrinode/pkg/metrics/metrics.go
+++ b/xtrinode/pkg/metrics/metrics.go
@@ -57,6 +57,31 @@ var (
 		[]string{"namespace", "name"},
 	)
 
+	XTrinodeDrainActive = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "xtrinode_drain_active",
+			Help: "Whether a XTrinode deletion drain is active (1=active, 0=inactive)",
+		},
+		[]string{"namespace", "name"},
+	)
+
+	XTrinodeDrainDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "xtrinode_drain_duration_seconds",
+			Help:    "Duration of XTrinode deletion drains in seconds",
+			Buckets: []float64{1, 5, 10, 30, 60, 120, 300, 600, 1800, 3600},
+		},
+		[]string{"namespace", "name", "result"},
+	)
+
+	XTrinodeDrainFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "xtrinode_drain_failures_total",
+			Help: "Total number of XTrinode drain failures by reason",
+		},
+		[]string{"namespace", "name", "reason"},
+	)
+
 	// Scaling metrics
 	WorkersCurrent = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -274,6 +299,9 @@ func init() {
 		XTrinodeSuspended,
 		XTrinodeResumed,
 		XTrinodeDeleted,
+		XTrinodeDrainActive,
+		XTrinodeDrainDuration,
+		XTrinodeDrainFailures,
 		// Scaling metrics
 		WorkersCurrent,
 		WorkersDesired,

--- a/xtrinode/pkg/metrics/metrics_test.go
+++ b/xtrinode/pkg/metrics/metrics_test.go
@@ -27,6 +27,9 @@ func TestSharedCollectorsRegistered(t *testing.T) {
 		"xtrinode_suspended_total",
 		"xtrinode_resumed_total",
 		"xtrinode_deleted_total",
+		"xtrinode_drain_active",
+		"xtrinode_drain_duration_seconds",
+		"xtrinode_drain_failures_total",
 		"xtrinode_workers_current",
 		"xtrinode_workers_desired",
 		"xtrinode_scale_up_total",
@@ -79,6 +82,9 @@ func seedSharedCollectors() {
 	XTrinodeSuspended.WithLabelValues(namespace, xtrinodeName).Add(0)
 	XTrinodeResumed.WithLabelValues(namespace, xtrinodeName).Add(0)
 	XTrinodeDeleted.WithLabelValues(namespace, xtrinodeName).Add(0)
+	XTrinodeDrainActive.WithLabelValues(namespace, xtrinodeName).Set(0)
+	XTrinodeDrainDuration.WithLabelValues(namespace, xtrinodeName, "query_complete").Observe(0)
+	XTrinodeDrainFailures.WithLabelValues(namespace, xtrinodeName, "query_check_error").Add(0)
 
 	WorkersCurrent.WithLabelValues(namespace, xtrinodeName).Set(0)
 	WorkersDesired.WithLabelValues(namespace, xtrinodeName).Set(0)


### PR DESCRIPTION
## Summary

- Implements query-aware deletion drain for XTrinode finalization so route removal waits on Trino query state instead of only elapsed time.
- Adds lifecycle drain annotations on deletion:
  - `xtrinode.analytics.xtrinode.io/drain-started-at`
  - `xtrinode.analytics.xtrinode.io/drain-completed-at`
  - `xtrinode.analytics.xtrinode.io/drain-result`
- Adds configurable operator drain settings and wires them through CLI flags, Helm values/templates, umbrella chart values, and Tilt values:
  - `gatewayDrainDuration`
  - `gatewayDrainRequeueInterval`
- Adds Prometheus lifecycle metrics for active drains, drain duration, drain failure reasons, and API server resume lease errors.
- Adds a Grafana lifecycle dashboard to the observability chart for active drains, drain duration, drain failures, lifecycle totals, resume activity, and reconciliation errors.
- Extends the Gateway UI with runtime draining visibility, including draining counts and estimated completion timing.
- Expands regression and Robot coverage for the drain state machine, annotation contract, stale completion handling, gateway draining state, and namespace guardrail lifecycle behavior.
- Updates troubleshooting and Helm documentation for the new lifecycle/drain observability signals.

This closes #12.

## Validation

- [x] Relevant local checks passed.
- [x] Skipped checks are explained below.

Checks run:

- `GOCACHE=/tmp/trinode-go-build-cache /usr/local/go/bin/go test ./controllers`
- `GOCACHE=/tmp/trinode-go-build-cache /usr/local/go/bin/go test ./controllers ./pkg/gateway ./pkg/metrics ./internal/config`
- `make test-e2e-local UV=bin/uv` - 69 tests, 68 passed, 1 skipped
- `make test-e2e-local-loadtest UV=bin/uv` - 2 passed
- `make test-e2e-local-operator-stress UV=bin/uv` - 1 passed
- `env UV_CACHE_DIR=/tmp/xtrinode-uv-cache bin/uv run --project tilt/e2e robot --outputdir tilt/e2e/results/drain-reaudit tilt/e2e/robot/16_namespace_guardrail_contracts.robot`
- `git diff --check`
- `git diff --cached --check`

GKE validation:

- Built and pushed issue #12 images to Artifact Registry.
- Deployed to `project-40642592-0c4f-4ce1-9d6`, cluster `xtrinode-gke-test`, zone `us-central1-a`.
- Verified operator, API server, and gateway rollouts.
- Verified live operator args include `--gateway-drain-duration=5m` and `--gateway-drain-requeue-interval=30s`.
- Verified the lifecycle dashboard ConfigMap exists in `monitoring`.
- Ran `make gcp-keda-resume-smoke` successfully, covering gateway query routing, KEDA scale-up, query completion, KEDA scale-down, auto-suspend, and gateway-triggered resume.
- Manually exercised deletion drain on GKE and verified `drain-started-at`, `drain-completed-at`, `drain-result=query_complete`, and operator finalizer removal.
- Redeployed a small r2 operator hardening after the manual GKE check exposed a stale-delete reconcile noise path, then reran a disposable GKE drain check and confirmed recent operator logs had no drain completion or reconciler errors.

Skipped checks:

- None intentionally skipped for the touched areas. The local e2e suite has one expected opt-in GKE skip when not running the live GKE wrapper.

## Risk

Moderate. This changes the deletion lifecycle for XTrinode resources and adds new metrics/UI/documentation around it. The behavior is intended to reduce disruption by waiting for active queries to finish before cleanup, with a time fallback only when query inspection is unavailable after the configured drain window.

Compatibility notes:

- Existing defaults preserve a 5 minute drain window and 30 second requeue interval.
- Existing XTrinode resources do not require spec changes.
- New annotations and metrics are additive.
- Helm values are backward compatible and defaulted.

## Release Impact

- [x] This PR does not change release versioning, image publishing, or Helm chart packaging.
- [ ] This PR changes release behavior and the impact is described below.

Runtime deployment impact:

- Operator Helm values now expose drain timing knobs.
- Observability chart now installs an additional lifecycle dashboard ConfigMap when dashboards are enabled.
- Gateway UI now renders drain lifecycle state from route metadata.

## Notes

- Manual GKE validation used temporary/disposable XTrinodes and cleaned them up afterward.
- The GKE control plane was left on the validated issue #12 images after testing:
  - operator: `issue-12-drain-gke-20260520-r2`
  - API server and gateway: `issue-12-drain-gke-20260520`
