### PR TITLE
build(deps): bump observability Prometheus stack to 85.2.0

### DIFF
--- a/helm/xtrinode-observability/Chart.lock
+++ b/helm/xtrinode-observability/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 58.0.0
+  version: 85.2.0
 - name: xtrinode-vector
   repository: file://../xtrinode-vector
   version: 0.1.0
-digest: sha256:7fdf287304450ef5f6c320d11501f85446d23ced3a8f0f014fabdba34f5d15d6
-generated: "2026-05-05T13:23:00.43485862+02:00"
+digest: sha256:b7284e2fd0eab87755c1d8d5408e4f37ee90c274313626b3c1807461c2e6c5ec
+generated: "2026-05-20T20:01:36.421472459Z"

--- a/helm/xtrinode-observability/Chart.yaml
+++ b/helm/xtrinode-observability/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 name: xtrinode-observability
 description: XTrinode observability stack with Prometheus and Vector
 type: application
+kubeVersion: ">=1.32.0-0"
 version: 0.1.0
 appVersion: "0.1.0"
 keywords:
@@ -18,7 +19,7 @@ maintainers:
 dependencies:
   - name: kube-prometheus-stack
     alias: prometheus-stack
-    version: "58.0.0"
+    version: "85.2.0"
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus-stack.enabled
   - name: xtrinode-vector

--- a/helm/xtrinode-observability/README.md
+++ b/helm/xtrinode-observability/README.md
@@ -8,6 +8,9 @@ This chart owns the GCP/local observability stack for XTrinode:
 The chart intentionally disables generic cluster infrastructure monitors by default (`nodeExporter`,
 kubelet, API server, scheduler, etc.) so it can coexist with an existing cluster monitoring stack.
 XTrinode charts render their own `ServiceMonitor` resources when Prometheus is enabled.
+The chart follows XTrinode's Kubernetes target and requires Kubernetes 1.32 or newer. Its CRD
+upgrade job is enabled by default so existing installs receive Prometheus Operator CRD updates
+during chart upgrades.
 This chart also renders an optional Grafana dashboard ConfigMap for lifecycle drain state and API
 server Lease acquired/gated/error outcomes. It is enabled by default with the
 `grafana_dashboard=1` label used by the Grafana sidecar.

--- a/helm/xtrinode-observability/values.yaml
+++ b/helm/xtrinode-observability/values.yaml
@@ -2,6 +2,9 @@
 
 prometheus-stack:
   enabled: true
+  crds:
+    upgradeJob:
+      enabled: true
   defaultRules:
     create: false
   alertmanager:

--- a/tilt/scripts/deploy-local-stack.sh
+++ b/tilt/scripts/deploy-local-stack.sh
@@ -18,14 +18,27 @@ gateway_chart="${ROOT_DIR}/helm/xtrinode-gateway"
 observability_chart="${ROOT_DIR}/helm/xtrinode-observability"
 values_dir="${ROOT_DIR}/tilt/deployments/values"
 
-if [ ! -f "${operator_chart}/charts/keda-2.18.0.tgz" ]; then
-  echo "KEDA chart dependency not found, running helm dependency build for operator chart"
-  helm dependency build "$operator_chart"
-fi
-if [ ! -f "${observability_chart}/charts/kube-prometheus-stack-58.0.0.tgz" ]; then
-  echo "Prometheus chart dependency not found, running helm dependency build for observability chart"
-  helm dependency build "$observability_chart"
-fi
+helm_dependencies_ready() {
+  local chart_path="$1"
+
+  helm dependency list "$chart_path" | awk '
+    NR == 1 || NF == 0 { next }
+    $NF != "ok" { exit 1 }
+  '
+}
+
+ensure_helm_dependencies() {
+  local chart_path="$1"
+  local chart_name="$2"
+
+  if ! helm_dependencies_ready "$chart_path"; then
+    echo "${chart_name} chart dependencies are missing or out of date, running helm dependency build"
+    helm dependency build "$chart_path"
+  fi
+}
+
+ensure_helm_dependencies "$operator_chart" "Operator"
+ensure_helm_dependencies "$observability_chart" "Observability"
 
 kubectl create namespace "$OPERATOR_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
 kubectl create namespace "$GATEWAY_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -

--- a/tilt/scripts/preload-local-images.sh
+++ b/tilt/scripts/preload-local-images.sh
@@ -13,13 +13,15 @@ postgres:16-alpine
 python:3.12-alpine
 redis:7.4-alpine
 bitnami/jmx-exporter@sha256:7c0014b7e1d736faec9760a89727389ba1ba7ad920c764417167abecfb7fd032
-quay.io/prometheus-operator/prometheus-operator:v0.73.0
-quay.io/prometheus-operator/prometheus-config-reloader:v0.73.0
-quay.io/prometheus/prometheus:v2.51.1
-registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
-ghcr.io/kedacore/keda:2.18.0
-ghcr.io/kedacore/keda-metrics-apiserver:2.18.0
-ghcr.io/kedacore/keda-admission-webhooks:2.18.0"
+quay.io/prometheus-operator/prometheus-operator:v0.90.1
+quay.io/prometheus-operator/prometheus-config-reloader:v0.90.1
+quay.io/prometheus/prometheus:v3.11.3-distroless
+ghcr.io/jkroepke/kube-webhook-certgen:1.8.2
+docker.io/busybox:latest
+registry.k8s.io/kubectl:v1.32.3
+ghcr.io/kedacore/keda:2.19.0
+ghcr.io/kedacore/keda-metrics-apiserver:2.19.0
+ghcr.io/kedacore/keda-admission-webhooks:2.19.0"
 
 LOCAL_PRELOAD_IMAGES="${LOCAL_PRELOAD_IMAGES:-$DEFAULT_LOCAL_PRELOAD_IMAGES}"
 


### PR DESCRIPTION
## Summary

- Bump the observability chart's `kube-prometheus-stack` dependency from `58.0.0` to `85.2.0` and refresh the lock digest.
- Add an observability chart `kubeVersion` guard aligned with the current XTrinode local Kubernetes target (`>=1.32.0-0`).
- Enable the Prometheus Operator CRD upgrade job so chart upgrades can apply the newer monitoring CRDs before the operator rolls forward.
- Replace version-specific local chart archive checks in `tilt/scripts/deploy-local-stack.sh` with `helm dependency list` status checks, so stale cached dependencies are rebuilt instead of silently reused.
- Update local preload images to match the rendered Prometheus Operator, Prometheus, webhook/CRD-upgrade, and KEDA images used by the Helm charts.

## Validation

- [x] Relevant local checks passed.
- [x] Skipped checks are explained below.

Checks run:

- `bash -n tilt/scripts/deploy-local-stack.sh`
- `bash -n tilt/scripts/preload-local-images.sh`
- `helm dependency list helm/xtrinode-observability`
- `helm lint helm/xtrinode-observability`
- `helm template xtrinode-observability helm/xtrinode-observability --namespace monitoring -f tilt/deployments/values/observability.yaml`
- `helm template xtrinode-observability helm/xtrinode-observability --namespace monitoring --kube-version 1.32.3`
- `make lint-helm`
- `make helm-template`

Skipped checks: none.

## Risk

Medium. This is a major `kube-prometheus-stack` chart upgrade and moves the bundled Prometheus Operator/Prometheus stack forward. The patch reduces upgrade risk by enabling the upstream CRD upgrade job, adding an explicit Kubernetes compatibility guard, and updating local dependency/image preload paths that would otherwise keep using stale versions.

User-visible impact is limited to the observability stack. The chart now requires Kubernetes `1.32+`, matching the repository's current local Kubernetes target.

## Release Impact

- [ ] This PR does not change release versioning, image publishing, or Helm chart packaging.
- [x] This PR changes release behavior and the impact is described below.

This changes the observability Helm dependency, rendered observability support images, CRD upgrade behavior, and local stack dependency preparation. It does not change XTrinode chart versions, component app versions, or release artifact naming.

## Notes

- This intentionally replaces the narrow chart-only dependency bump with the companion local deploy and preload fixes needed for the upgraded observability stack.
