### PR TITLE
Add runtime diagnostics and nodepool retain coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1440,6 +1440,11 @@ gcp-capg-nodepool-smoke: gcp-configure-kubectl ## Apply a XTrinode CR that creat
 	@echo "Running CAPG nodepool smoke..."
 	TARGET_NAMESPACE=$(CAPG_WORKLOAD_NAMESPACE) CLUSTER_NAME=$(CAPG_WORKLOAD_CLUSTER_NAME) WAIT_TIMEOUT=$(CAPG_WAIT_TIMEOUT) KUBECTL="$(KUBECTL)" bash scripts/capi/test-xtrinode-nodepool.sh
 
+.PHONY: gcp-capg-nodepool-retain-smoke
+gcp-capg-nodepool-retain-smoke: gcp-configure-kubectl ## Verify removing spec.nodePool retains CAPG provider resources
+	@echo "Running CAPG nodepool retain smoke..."
+	TARGET_NAMESPACE=$(CAPG_WORKLOAD_NAMESPACE) CLUSTER_NAME=$(CAPG_WORKLOAD_CLUSTER_NAME) WAIT_TIMEOUT=$(CAPG_WAIT_TIMEOUT) VERIFY_NODEPOOL_REMOVAL_RETAIN=true KUBECTL="$(KUBECTL)" bash scripts/capi/test-xtrinode-nodepool.sh
+
 .PHONY: gcp-capg-workload-kubeconfig
 gcp-capg-workload-kubeconfig: gcp-configure-kubectl ## Write the generated CAPG workload cluster kubeconfig
 	$(KUBECTL) get secret $(CAPG_WORKLOAD_CLUSTER_NAME)-user-kubeconfig -n $(CAPG_WORKLOAD_NAMESPACE) -o jsonpath='{.data.value}' | base64 -d > $(CAPG_WORKLOAD_KUBECONFIG)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -421,7 +421,10 @@ flowchart TB
   event["Watch event<br/>XTrinode, owned runtime child,<br/>catalog ConfigMap, referenced ConfigMap/Secret,<br/>gateway route ConfigMap,<br/>namespace guardrail"] --> reconcile["Reconcile XTrinode"]
   reconcile --> finalizer["Ensure finalizer"]
   finalizer --> commands["Process command annotations<br/>resume, suspend, auto-suspend, wake"]
-  commands --> suspended{"spec.suspended?"}
+  commands --> removednp{"spec.nodePool removed<br/>and observed pool exists?"}
+  removednp -- yes --> retainnp["Retain old node pool<br/>remove owner refs"]
+  removednp -- no --> suspended{"spec.suspended?"}
+  retainnp --> suspended
 
   suspended -- yes --> suspend["Suspend flow<br/>drain, disable scaling, scale down"]
   suspended -- no --> resume["Resume flow<br/>restore coordinator and worker floor"]
@@ -447,11 +450,14 @@ The effective order is important:
 1. Catalog discovery happens before resource rendering so catalog mounts and
    secret-derived environment variables are reflected in pod templates.
 2. Namespace guardrails are applied before runtime resources are created.
-3. If a node pool is requested, node-pool readiness blocks Trino resource
+3. If `spec.nodePool` was removed and status records a previously provisioned
+   pool, the operator retains that pool before suspend/resume and before the
+   observed runtime shape is refreshed.
+4. If a node pool is requested, node-pool readiness blocks Trino resource
    scheduling; without a node pool, the node-pool step is skipped after resources.
-4. Wake TTL runs before KEDA so an expired wake window can lower KEDA
+5. Wake TTL runs before KEDA so an expired wake window can lower KEDA
    `minReplicaCount` in the same reconciliation pass.
-5. Runtime readiness gates the final gateway state. A not-yet-ready runtime gets
+6. Runtime readiness gates the final gateway state. A not-yet-ready runtime gets
    a `RESUMING` route and a requeue; only a ready runtime gets the `RUNNING` route
    and `Ready` status.
 
@@ -461,6 +467,19 @@ operator owns only its configured guardrail object names
 and labels those objects for watch ownership. Their spec, label, annotation,
 create, and delete events enqueue all `XTrinode`s in that namespace for drift
 repair while ignoring quota status churn.
+
+Clusters that already enforce namespace quota, default `LimitRange`s, or
+namespace label policy should choose the guardrail mode deliberately. Use
+`managed` only when XTrinode should own the configured quota and limit object
+names, `createOnly` when it may create missing guardrails but must not take over
+existing objects, `observe` when another platform controller owns enforcement,
+and `disabled` when namespace policy is entirely external. External quota and
+limit policy must reserve enough headroom for the resolved runtime shape,
+rolling-update surge, KEDA/HPA worker floors, and resumed capacity; otherwise the
+operator reports quota or scheduling blockers while Kubernetes remains the
+detailed source of truth. Namespace labels required by cluster admission policy
+should be applied before creating runtimes so generated Trino, KEDA, and
+node-pool resources are admitted consistently.
 
 ## API Server Resume Gate
 
@@ -544,10 +563,17 @@ strategies do not reserve surge.
 Runtime status also carries focused operational conditions. `SchedulingReady`
 summarizes pod and deployment scheduling blockers, and `PlacementReady`,
 `TaintsReady`, `QuotaReady`, and `CapacityReady` classify common placement,
-taint/toleration, namespace quota, and node capacity failures. `NodePoolFitReady`
+taint/toleration, namespace quota, and node capacity failures. When runtime pods
+are pending, the operator also inspects Ready schedulable Nodes, active Pods, and
+DaemonSets to report selector mismatch, untolerated taints, allocatable CPU,
+memory, ephemeral-storage, pod-slot pressure, and DaemonSet overhead. This
+diagnostic pass is bounded to status conditions; Kubernetes Events, pod status,
+and scheduler diagnostics remain the detailed source of truth. `NodePoolFitReady`
 records best-effort fit checks between resolved pod resources and known provider
-machine types. Kubernetes Events and pod status remain the detailed source of
-truth.
+machine types. For configured node pools, `NodePoolReady` also correlates hard
+provisioning failures from Cluster API resources, provider managed-pool resources,
+child Machines, and Machine infrastructure refs when those resources expose
+failure fields or failed/error conditions.
 
 ### Runtime Configuration Layers
 
@@ -593,6 +619,7 @@ boundaries.
 | Override route/resume capacity | Set `spec.routing.capacityUnits`. |
 | Bigger or different nodes with the same pod resources | Set `spec.nodePool` provider and machine type fields; use `spec.nodePool.deletionPolicy` to choose delete, retain, or scale-to-zero behavior on XTrinode deletion. |
 | More workers or provider node-pool bounds | Set `spec.nodePool.minNodes`, `maxNodes`, prewarm, spot, labels, taints, disk, or zone fields. |
+| Stop managing a provisioned node pool | Remove `spec.nodePool`; the operator uses the last observed node-pool identity to remove XTrinode owner references and retain the provider resources. |
 | Chart-shaped pod, image, or Trino config changes | Use `spec.valuesOverlay`, subject to privileged overlay admission. |
 
 Prefer the smallest preset that fits steady-state query needs, then increase the
@@ -625,6 +652,65 @@ installations can add ValidatingAdmissionPolicy, OPA Gatekeeper, Kyverno, or an
 equivalent policy layer for stricter local registry, Secret, and annotation
 rules.
 
+Trusted overlay editor RBAC should be narrow and namespace-scoped:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: xtrinode-overlay-editor
+  namespace: team-analytics
+rules:
+  - apiGroups: ["analytics.xtrinode.io"]
+    resources: ["xtrinodes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["analytics.xtrinode.io"]
+    resources: ["xtrinodes/valuesoverlay"]
+    verbs: ["update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: xtrinode-overlay-editors
+  namespace: team-analytics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: xtrinode-overlay-editor
+subjects:
+  - kind: Group
+    name: platform-overlay-editors
+    apiGroup: rbac.authorization.k8s.io
+```
+
+Tenant runtime authors should not receive
+`analytics.xtrinode.io/xtrinodes/valuesoverlay`. Status or read-only roles also
+must not include it.
+
+Local overlay policy examples:
+
+| Policy Area | Example Rule |
+| --- | --- |
+| Image registry | Allow `valuesOverlay.image.repository` only when empty or prefixed with an approved registry such as `registry.example.com/xtrinode/`. Pair this with image signing or digest policy when available. |
+| Secret references | Keep references namespace-local and restrict overlay Secret names with a prefix such as `xtrinode-`. Secret label checks require a policy engine that can inspect referenced Secrets; require a label such as `xtrinode.io/overlay-readable=true` when available. |
+| Service annotations | Reject annotation keys outside a small allowlist, for example `prometheus.io/scrape`, `prometheus.io/port`, and explicitly approved cloud-provider keys. Validate structured annotation values separately. |
+| Node selectors | Use typed `spec.placement`, not `valuesOverlay`, and allow only approved keys and values such as `xtrinode.io/nodepool=analytics-standard`. |
+| Existing pools | Allow only approved `spec.placement.existingNodePool` pairs, for example `provider: gcp, name: analytics-standard`. |
+| Tolerations | Prefer narrow `Equal` tolerations for XTrinode-dedicated taints such as `xtrinode.io/workload=trino:NoSchedule`; avoid broad `Exists` tolerations for tenant namespaces. |
+
+ValidatingAdmissionPolicy-style CEL for an approved image registry:
+
+```text
+!has(object.spec.valuesOverlay) ||
+!has(object.spec.valuesOverlay.image) ||
+!has(object.spec.valuesOverlay.image.repository) ||
+object.spec.valuesOverlay.image.repository.startsWith("registry.example.com/xtrinode/")
+```
+
+For catalog credentials, prefer `XTrinodeCatalog.propertySecretRefs` and typed
+Secret fields. The catalog webhook already checks whether the admission user can
+`get` referenced Secrets in the catalog namespace.
+
 When Trino HTTP authentication is enabled, configure `spec.trinoControlAuth` so
 the operator and worker shutdown hooks can call internal Trino lifecycle APIs:
 
@@ -648,6 +734,79 @@ also rejects raw config-property overrides that disable the HTTP listener or
 change the HTTP port. Use `valuesOverlay.service.port` for supported port
 changes so generated Services, routes, status, autosuspend, and graceful
 shutdown stay aligned.
+
+### Admission Webhook Operations
+
+XTrinode admission webhooks are served by the operator process. They default and
+validate `XTrinode` resources and validate `XTrinodeCatalog` resources. Keep
+`webhook.failurePolicy: Fail` in production so privileged overlay checks,
+catalog Secret checks, break-glass checks, defaults, and runtime-shape
+validation fail closed when the webhook is unreachable.
+
+Rollout checklist:
+
+1. Confirm CRDs are installed before applying `XTrinode` or `XTrinodeCatalog`
+   objects.
+2. Confirm the operator Deployment is ready and exposes the webhook port through
+   its Service.
+3. Confirm the webhook TLS Secret exists and is mounted into the operator pod.
+4. Confirm the `MutatingWebhookConfiguration` and
+   `ValidatingWebhookConfiguration` point at the operator Service and have a
+   `caBundle`.
+5. Keep `webhook.timeoutSeconds` below the API server request timeout and high
+   enough for SubjectAccessReview checks used by privileged overlay and catalog
+   Secret authorization.
+6. Apply a harmless server-side dry-run `XTrinode` create or update before
+   rolling changes to tenant namespaces.
+
+Useful checks:
+
+```bash
+kubectl -n xtrinode-system get deploy,svc,endpointslices,secret \
+  -l app.kubernetes.io/name=xtrinode-operator
+
+kubectl get mutatingwebhookconfiguration,validatingwebhookconfiguration \
+  -l app.kubernetes.io/name=xtrinode-operator -o wide
+
+kubectl -n xtrinode-system logs deploy/xtrinode-operator --tail=200
+
+kubectl auth can-i update xtrinodes/valuesoverlay.analytics.xtrinode.io \
+  -n team-analytics --as user@example.com
+```
+
+`failurePolicy: Ignore` is an emergency-only availability tradeoff. While it is
+active, the Kubernetes API server can admit `valuesOverlay` or
+`helmChartConfig` changes without the privileged authorization check, catalog
+Secret references without the webhook Secret access check, specs that should
+have been rejected, and objects that miss webhook defaults. If `Ignore` is used,
+scope it to the shortest possible window, record the reason, review all
+`XTrinode` and `XTrinodeCatalog` changes admitted during that window, and revert
+to `Fail` as soon as the webhook Service is healthy.
+
+When creates or updates fail with webhook connection, TLS, or timeout errors:
+
+1. Stop broad rollout automation that writes `XTrinode` or `XTrinodeCatalog`
+   resources.
+2. Check operator readiness, logs, Service endpoints, and webhook configuration.
+3. Roll back the Helm release if the failure started after an upgrade.
+4. Confirm the webhook Secret name matches the Deployment volume and webhook
+   `caBundle`.
+5. Retry a server-side dry-run update against a non-critical runtime.
+6. Use `failurePolicy: Ignore` only when the control plane must admit unrelated
+   changes before the webhook can be restored.
+
+The API server is not in the admission webhook serving path. If the API server is
+down but the operator webhook is healthy, Kubernetes admission for `XTrinode`
+objects can still work. The outage affects direct lifecycle API calls and gateway
+auto-resume requests. Operators with Kubernetes RBAC can still patch
+`spec.suspended` directly, and the admission webhook still validates that patch.
+
+Alert or run a periodic check for operator Deployment availability, empty
+webhook Service endpoints, webhook timeout/TLS/connection errors, admission
+latency approaching `webhook.timeoutSeconds`, webhook certificate expiry,
+`failurePolicy` changes away from `Fail`, denied privileged overlay or catalog
+Secret admission attempts, API server availability, resume Lease errors, and
+sustained gated resume or suspend requests.
 
 ## Gateway Route States
 
@@ -701,6 +860,21 @@ stateDiagram-v2
   Deleting --> [*]: resources cleaned and finalizer removed
 ```
 
+The compact ordering table below is the operational contract for lifecycle race
+questions:
+
+| Operation | Gate Or Trigger | Operator Order | Route State Before Ready | New Query Acceptance |
+| --- | --- | --- | --- | --- |
+| Create or spec update | Kubernetes watch event | Process commands, apply guardrails, optionally wait for node pool, render Trino resources, reconcile wake TTL, configure KEDA or fixed workers, check runtime readiness | `RESUMING` until readiness passes | Rejected until route becomes `RUNNING` |
+| Remove node pool | `spec.nodePool` removed while status records a previously provisioned node pool | Remove XTrinode owner references from the last observed provider node-pool resources, refresh observed runtime shape, then reconcile the runtime without a managed node pool | Follows normal create or update route behavior | No direct query impact; runtime readiness still gates `RUNNING` |
+| Explicit suspend | Direct spec change or API-server suspend command; API requests use a suspend Lease | Set `Suspending`, publish `PAUSED`, check active queries, disable KEDA or native HPA, scale coordinator/workers down, optionally scale node pool down, mark `Suspended` | `PAUSED` before scale-down starts | Rejected while existing query drain is checked |
+| Autosuspend | Idle check after runtime readiness | Patch `spec.suspended=true` through the same command path, then follow suspend ordering | `PAUSED` after the suspend reconcile publishes route state | Rejected after `PAUSED` is visible to the gateway |
+| Explicit resume | Direct spec change or API-server resume command; API requests use a runtime Lease | Clear suspended intent, set `Resuming`, apply wake window, restore node-pool minimum when needed, scale coordinator, seed fixed/native-HPA workers when needed, reconcile KEDA, wait for readiness | `RESUMING` until readiness passes | Rejected with retry guidance until `RUNNING` |
+| Gateway auto-resume | No selectable backend or coordinator connection failure | Gateway calls API server, API server acquires pool or runtime Lease and annotates target runtime, operator follows resume ordering | Existing `PAUSED` or `RESUMING` backend remains non-routable | Original query gets `503` and `Retry-After`; retry can run after `RUNNING` |
+| KEDA handoff | `spec.keda.enabled=true` and scaler config present | Wake TTL is reconciled before KEDA so expired wake floors are removed, then the ScaledObject is created or updated; suspend disables KEDA before scale-down | Route state still follows runtime readiness, not KEDA object creation alone | New queries require `RUNNING`; KEDA may scale workers after resume |
+| Native HPA handoff | `valuesOverlay.server.autoscaling.enabled=true` | Resume scales the coordinator and seeds worker replicas to the HPA floor if the target is zero; suspend deletes the HPA before scale-down | Route state still follows runtime readiness | New queries require `RUNNING`; HPA owns worker scaling after seed |
+| Delete | Deletion timestamp and finalizer | Mark route `DRAINING`, wait for query-aware drain or fallback window, deregister route, delete KEDA and Trino resources, apply node-pool deletion policy, reconcile guardrails, remove finalizer | `DRAINING`, then `REMOVED` | New queries rejected; sticky continuations allowed only while `DRAINING` |
+
 ### Create Or Update
 
 For create and update operations, the operator resolves catalogs, applies
@@ -708,6 +882,17 @@ guardrails, optionally waits for node-pool readiness, renders Kubernetes
 resources, configures worker scaling, waits for runtime readiness, publishes the
 ready gateway route, and updates status. Spec changes are the normal source of
 reconciliation.
+
+Removing `spec.nodePool` from a live runtime stops XTrinode management of the
+previously provisioned provider node pool. The operator uses
+`status.observedRuntimeShape.nodePool` to reconstruct the provider, mode, and
+resolved node-pool name, removes XTrinode owner references from the CAPI/CAP*
+resources, refreshes observed runtime shape, and continues reconciliation
+without managed node-pool ownership. This is a retain operation; it does not
+delete or scale down the provider resources. If the runtime is deleted after the
+field is removed but before a normal update reconcile completes, finalizer
+cleanup applies the same observed-status retain path before removing the
+XTrinode finalizer.
 
 ### Suspend
 
@@ -735,6 +920,13 @@ guardrails, and removes the finalizer. `deletionPolicy: Retain` removes
 XTrinode owner references and leaves managed node-pool resources in place, while
 `deletionPolicy: ScaleToZero` scales the pool down through the node-pool scale
 path and then retains the object.
+
+`ScaleToZero` is a best-effort provider handoff. The operator patches the
+provider node-pool scale fields or autoscaler annotations it owns, then retains
+the object. Actual cloud node removal can lag behind finalizer completion, and
+provider quotas, autoscaler limits, or provider controllers may keep nodes longer
+than XTrinode reconciliation. Inspect the retained CAPI/CAP* resource and cloud
+provider node-pool status when cost or capacity release is urgent.
 
 ## Catalog Flow
 

--- a/helm/xtrinode-operator/templates/clusterrole.yaml
+++ b/helm/xtrinode-operator/templates/clusterrole.yaml
@@ -45,6 +45,9 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments/scale"]
   verbs: ["get", "patch", "update"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["get", "list", "watch"]
 
 # HorizontalPodAutoscaler permissions
 - apiGroups: ["autoscaling"]
@@ -69,6 +72,9 @@ rules:
 # Runtime readiness permissions
 - apiGroups: ["discovery.k8s.io"]
   resources: ["endpointslices"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["nodes"]
   verbs: ["get", "list", "watch"]
 
 # ServiceAccount permissions (for creating ServiceAccounts for XTrinode instances)
@@ -136,6 +142,17 @@ rules:
     - machinepools/status
     - machinepools/finalizers
   verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+
+# Provider machine diagnostics for node-pool provisioning failures
+- apiGroups: ["infrastructure.cluster.x-k8s.io"]
+  resources:
+    - awsmachines
+    - awsmachines/status
+    - azuremachines
+    - azuremachines/status
+    - gcpmachines
+    - gcpmachines/status
+  verbs: ["get", "list", "watch"]
 
 # Infrastructure provider permissions used by the node pool adapter
 - apiGroups: ["infrastructure.cluster.x-k8s.io"]

--- a/helm/xtrinode/README.md
+++ b/helm/xtrinode/README.md
@@ -175,6 +175,16 @@ Raw config-property overlays may not disable the Trino HTTP listener or override
 `http-server.http.port` directly. Use `valuesOverlay.service.port` for supported HTTP port changes
 so generated Services, routes, status, autosuspend, and graceful shutdown use the same port.
 
+### Admission Webhook Failure Policy
+
+`xtrinode-operator.webhook.failurePolicy` defaults to `Fail`. Keep that default in production so
+privileged overlay authorization, catalog Secret authorization, break-glass checks, defaults, and
+runtime-shape validation fail closed when the operator webhook is unreachable.
+
+Setting it to `Ignore` is an emergency availability tradeoff. During that window, the Kubernetes API
+server can admit `XTrinode` or `XTrinodeCatalog` changes that the webhook would normally reject or
+default. Review all admitted changes and revert to `Fail` after the webhook Service is healthy.
+
 ### Control-Plane Node Pool Placement
 
 Keep XTrinode control-plane agents on a small, always-on node pool and keep Trino coordinator and

--- a/scripts/capi/test-xtrinode-nodepool.sh
+++ b/scripts/capi/test-xtrinode-nodepool.sh
@@ -16,6 +16,7 @@ AUTO_SUSPEND_AFTER="${AUTO_SUSPEND_AFTER:-1h}"
 WAIT_FOR_NODEPOOL="${WAIT_FOR_NODEPOOL:-true}"
 WAIT_FOR_WORKLOAD_NODES="${WAIT_FOR_WORKLOAD_NODES:-true}"
 WAIT_FOR_TRINO_ROLLOUT="${WAIT_FOR_TRINO_ROLLOUT:-false}"
+VERIFY_NODEPOOL_REMOVAL_RETAIN="${VERIFY_NODEPOOL_REMOVAL_RETAIN:-false}"
 WAIT_TIMEOUT="${WAIT_TIMEOUT:-30m}"
 KUBECTL="${KUBECTL:-kubectl}"
 
@@ -70,6 +71,61 @@ workload_nodepool_converged() {
   fi
 
   printf '%s\n' "$readiness" | awk 'NF && $2 != "True" { bad = 1 } END { exit bad }'
+}
+
+xtrinode_owner_reference_names() {
+  local kind="$1"
+  local name="$2"
+
+  "$KUBECTL" get "${kind}/${name}" -n "$TARGET_NAMESPACE" \
+    -o jsonpath="{range .metadata.ownerReferences[?(@.kind==\"XTrinode\")]}{.name}{\"\n\"}{end}"
+}
+
+retained_resource_is_unowned_by_xtrinode() {
+  local kind="$1"
+  local name="$2"
+  local owners
+
+  owners="$(xtrinode_owner_reference_names "$kind" "$name")" || return 1
+  ! printf '%s\n' "$owners" | grep -Fxq "$XTRINODE_NAME"
+}
+
+wait_for_retained_nodepool_resources() {
+  local wait_seconds
+  local deadline
+
+  wait_seconds="$(duration_to_seconds "$WAIT_TIMEOUT")"
+  deadline="$(( SECONDS + wait_seconds ))"
+
+  until "$KUBECTL" get "machinepool/${NODEPOOL_NAME}" "gcpmanagedmachinepool/${NODEPOOL_NAME}" -n "$TARGET_NAMESPACE" >/dev/null 2>&1; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "Timed out waiting for retained node-pool resources ${NODEPOOL_NAME}" >&2
+      exit 1
+    fi
+    sleep 10
+  done
+
+  until retained_resource_is_unowned_by_xtrinode machinepool "$NODEPOOL_NAME" \
+    && retained_resource_is_unowned_by_xtrinode gcpmanagedmachinepool "$NODEPOOL_NAME"; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "Timed out waiting for retained node-pool resources to drop XTrinode owner references" >&2
+      "$KUBECTL" get "machinepool/${NODEPOOL_NAME}" "gcpmanagedmachinepool/${NODEPOOL_NAME}" -n "$TARGET_NAMESPACE" -o yaml
+      exit 1
+    fi
+    sleep 10
+  done
+}
+
+verify_nodepool_removal_retain() {
+  echo "Verifying spec.nodePool removal retains provider node-pool resources..."
+  "$KUBECTL" patch xtrinode "$XTRINODE_NAME" -n "$TARGET_NAMESPACE" \
+    --type=merge \
+    -p '{"spec":{"nodePool":null}}'
+  "$KUBECTL" wait "xtrinode/${XTRINODE_NAME}" -n "$TARGET_NAMESPACE" \
+    --for=jsonpath='{.status.conditions[?(@.type=="NodePoolReady")].reason}'=NodePoolRetained \
+    --timeout="$WAIT_TIMEOUT"
+  wait_for_retained_nodepool_resources
+  echo "Retained MachinePool and GCPManagedMachinePool no longer have XTrinode owner references."
 }
 
 CONTROL_PLANE_VERSION="$(
@@ -198,6 +254,14 @@ if [ "$WAIT_FOR_NODEPOOL" = "true" ]; then
     fi
     echo "Skipping Trino rollout wait; CAPG managed node pools are created in the workload cluster and the smoke runtime remains suspended."
   fi
+fi
+
+if [ "$VERIFY_NODEPOOL_REMOVAL_RETAIN" = "true" ]; then
+  if [ "$WAIT_FOR_NODEPOOL" != "true" ]; then
+    echo "ERROR: VERIFY_NODEPOOL_REMOVAL_RETAIN=true requires WAIT_FOR_NODEPOOL=true" >&2
+    exit 1
+  fi
+  verify_nodepool_removal_retain
 fi
 
 "$KUBECTL" get xtrinode "$XTRINODE_NAME" -n "$TARGET_NAMESPACE" -o wide

--- a/scripts/test/gcp-refresh-edge-cases.sh
+++ b/scripts/test/gcp-refresh-edge-cases.sh
@@ -98,6 +98,8 @@ require_contains "scripts/capi/test-xtrinode-nodepool.sh" 'WAIT_FOR_WORKLOAD_NOD
   "CAPG smoke waits for workload-cluster nodes by default"
 require_contains "scripts/capi/test-xtrinode-nodepool.sh" 'WAIT_FOR_TRINO_ROLLOUT="${WAIT_FOR_TRINO_ROLLOUT:-false}"' \
   "CAPG smoke does not wait for management-cluster Trino rollout by default"
+require_contains "scripts/capi/test-xtrinode-nodepool.sh" 'VERIFY_NODEPOOL_REMOVAL_RETAIN="${VERIFY_NODEPOOL_REMOVAL_RETAIN:-false}"' \
+  "CAPG smoke keeps nodepool removal retain verification opt-in"
 require_contains "scripts/capi/test-xtrinode-nodepool.sh" 'XTRINODE_SUSPENDED="${XTRINODE_SUSPENDED:-true}"' \
   "CAPG provisioning-only smoke keeps the runtime suspended by default"
 require_contains "scripts/capi/test-xtrinode-nodepool.sh" 'NODEPOOL_SCALE_DOWN_ON_SUSPEND="${NODEPOOL_SCALE_DOWN_ON_SUSPEND:-false}"' \
@@ -110,5 +112,11 @@ require_contains "scripts/capi/test-xtrinode-nodepool.sh" 'xtrinode.io/node-pool
   "CAPG smoke verifies workload nodes by XTrinode nodepool label"
 require_contains "scripts/capi/test-xtrinode-nodepool.sh" 'Timed out waiting for workload nodes labelled xtrinode.io/node-pool=${NODEPOOL_NAME}' \
   "CAPG smoke handles the zero-matching-node wait edge case"
+require_contains "scripts/capi/test-xtrinode-nodepool.sh" 'NodePoolRetained' \
+  "CAPG smoke can verify spec.nodePool removal retention"
+require_contains "scripts/capi/test-xtrinode-nodepool.sh" 'Retained MachinePool and GCPManagedMachinePool no longer have XTrinode owner references.' \
+  "CAPG retain smoke checks provider resources were retained without XTrinode owners"
+require_contains "Makefile" "gcp-capg-nodepool-retain-smoke" \
+  "Makefile exposes the CAPG nodepool retain smoke"
 
 printf 'Completed %s edge-case checks.\n' "$CHECKS"

--- a/tilt/e2e/robot/10_xtrinode_resource_contracts.robot
+++ b/tilt/e2e/robot/10_xtrinode_resource_contracts.robot
@@ -10,6 +10,12 @@ ${TYPED_RUNTIME_NAME}           typed-runtime-shape
 ${TYPED_RUNTIME_NODE_LABEL}     cloud.google.com/gke-nodepool
 ${TYPED_RUNTIME_NODE_VALUE}     typed-shape
 ${SCHEDULING_BLOCKED_NAME}      schedulability-blocked
+${TAINT_BLOCKED_NAME}           schedulability-taint-blocked
+${TAINT_BLOCKED_NODE_LABEL}     xtrinode.io/e2e-taint-target
+${TAINT_BLOCKED_NODE_VALUE}     true
+${TAINT_BLOCKED_TAINT_KEY}      xtrinode.io/e2e-taint
+${TAINT_BLOCKED_TAINT_VALUE}    blocked
+${CAPACITY_BLOCKED_NAME}        schedulability-capacity-blocked
 
 *** Test Cases ***
 Rendered Trino Images Use Requested Version
@@ -147,12 +153,46 @@ Schedulability Conditions Classify Placement Blockers
     Command Should Succeed    kubectl    apply    -f    ${manifest}
     Command Should Succeed    kubectl    wait    xtrinode/${SCHEDULING_BLOCKED_NAME}    -n    ${NAMESPACE}    --for=condition=SchedulingReady=False    --timeout=${WAIT_TIMEOUT}
     Command Should Succeed    kubectl    wait    xtrinode/${SCHEDULING_BLOCKED_NAME}    -n    ${NAMESPACE}    --for=condition=PlacementReady=False    --timeout=${WAIT_TIMEOUT}
+    Wait Until Keyword Succeeds    120s    ${POLL_INTERVAL}    Runtime Condition Message Should Match    ${SCHEDULING_BLOCKED_NAME}    PlacementReady    False    PlacementBlocked    node selector|required node affinity|node affinity
     ${runtime}=    Set Variable    /tmp/xtrinode-schedulability-blocked-runtime.json
     ${json}=    Kubectl Output    get    xtrinode/${SCHEDULING_BLOCKED_NAME}    -n    ${NAMESPACE}    -o    json
     Create File    ${runtime}    ${json}
     JQ Should Match    ${runtime}    any(.status.conditions[]; .type == "SchedulingReady" and .status == "False" and .reason == "SchedulingBlocked") and any(.status.conditions[]; .type == "PlacementReady" and .status == "False" and .reason == "PlacementBlocked") and any(.status.conditions[]; .type == "TaintsReady" and .status == "True") and any(.status.conditions[]; .type == "QuotaReady" and .status == "True") and any(.status.conditions[]; .type == "CapacityReady" and .status == "True")
 
+Schedulability Conditions Classify Taint Blockers
+    [Setup]    Prepare Taint Blocker Contract
+    [Teardown]    Cleanup Taint Blocker Contract Objects
+    Command Should Succeed    kubectl    wait    xtrinode/${TAINT_BLOCKED_NAME}    -n    ${NAMESPACE}    --for=condition=SchedulingReady=False    --timeout=${WAIT_TIMEOUT}
+    Command Should Succeed    kubectl    wait    xtrinode/${TAINT_BLOCKED_NAME}    -n    ${NAMESPACE}    --for=condition=TaintsReady=False    --timeout=${WAIT_TIMEOUT}
+    Wait Until Keyword Succeeds    120s    ${POLL_INTERVAL}    Runtime Condition Message Should Match    ${TAINT_BLOCKED_NAME}    TaintsReady    False    TaintsBlocked    untolerated|taint|tolerat
+    ${runtime}=    Set Variable    /tmp/xtrinode-schedulability-taint-blocked-runtime.json
+    ${json}=    Kubectl Output    get    xtrinode/${TAINT_BLOCKED_NAME}    -n    ${NAMESPACE}    -o    json
+    Create File    ${runtime}    ${json}
+    JQ Should Match    ${runtime}    any(.status.conditions[]; .type == "SchedulingReady" and .status == "False" and .reason == "SchedulingBlocked") and any(.status.conditions[]; .type == "PlacementReady" and .status == "True") and any(.status.conditions[]; .type == "TaintsReady" and .status == "False" and .reason == "TaintsBlocked") and any(.status.conditions[]; .type == "QuotaReady" and .status == "True") and any(.status.conditions[]; .type == "CapacityReady" and .status == "True")
+
+Schedulability Conditions Classify Capacity Blockers
+    [Teardown]    Cleanup Capacity Blocker Contract Objects
+    Cleanup Capacity Blocker Contract Objects
+    ${manifest}=    Set Variable    /tmp/xtrinode-schedulability-capacity-blocked.json
+    ${json}=    Set Variable    {"apiVersion":"analytics.xtrinode.io/v1","kind":"XTrinode","metadata":{"name":"${CAPACITY_BLOCKED_NAME}","namespace":"${NAMESPACE}","labels":{"test.xtrinode.io/contract":"schedulability-capacity-blocked"}},"spec":{"size":"xs","minWorkers":1,"maxWorkers":1,"autoSuspendAfter":"30m","keda":{"enabled":false},"resources":{"coordinator":{"requests":{"cpu":"100000","memory":"384Mi"},"limits":{"cpu":"100000","memory":"768Mi"}},"worker":{"requests":{"cpu":"100000","memory":"512Mi"},"limits":{"cpu":"100000","memory":"1Gi"}}},"routing":{"header":"X-Trino-XTrinode=${NAMESPACE}/${CAPACITY_BLOCKED_NAME}","routingGroup":"schedulability-capacity-blocked"},"valuesOverlay":{"image":{"repository":"${TRINO_IMAGE_REPOSITORY}","tag":"${TRINO_IMAGE_TAG}","pullPolicy":"IfNotPresent"},"coordinator":{"additionalJVMConfig":["-Xmx768M","-XX:ReservedCodeCacheSize=128M"]},"worker":{"additionalJVMConfig":["-Xmx768M","-XX:ReservedCodeCacheSize=128M"]},"additionalConfigProperties":["query.max-memory=512MB","query.max-memory-per-node=384MB","memory.heap-headroom-per-node=256MB"]}}}
+    Create File    ${manifest}    ${json}
+    Command Should Succeed    kubectl    apply    -f    ${manifest}
+    Command Should Succeed    kubectl    wait    xtrinode/${CAPACITY_BLOCKED_NAME}    -n    ${NAMESPACE}    --for=condition=SchedulingReady=False    --timeout=${WAIT_TIMEOUT}
+    Command Should Succeed    kubectl    wait    xtrinode/${CAPACITY_BLOCKED_NAME}    -n    ${NAMESPACE}    --for=condition=CapacityReady=False    --timeout=${WAIT_TIMEOUT}
+    Wait Until Keyword Succeeds    120s    ${POLL_INTERVAL}    Runtime Condition Message Should Match    ${CAPACITY_BLOCKED_NAME}    CapacityReady    False    CapacityBlocked    bestAvailable|insufficient allocatable|Insufficient cpu|insufficient cpu
+    ${runtime}=    Set Variable    /tmp/xtrinode-schedulability-capacity-blocked-runtime.json
+    ${json}=    Kubectl Output    get    xtrinode/${CAPACITY_BLOCKED_NAME}    -n    ${NAMESPACE}    -o    json
+    Create File    ${runtime}    ${json}
+    JQ Should Match    ${runtime}    any(.status.conditions[]; .type == "SchedulingReady" and .status == "False" and .reason == "SchedulingBlocked") and any(.status.conditions[]; .type == "PlacementReady" and .status == "True") and any(.status.conditions[]; .type == "TaintsReady" and .status == "True") and any(.status.conditions[]; .type == "QuotaReady" and .status == "True") and any(.status.conditions[]; .type == "CapacityReady" and .status == "False" and .reason == "CapacityBlocked")
+
 *** Keywords ***
+Runtime Condition Message Should Match
+    [Arguments]    ${runtime}    ${condition_type}    ${condition_status}    ${reason}    ${message_pattern}
+    ${runtime_file}=    Set Variable    /tmp/xtrinode-${runtime}-${condition_type}.json
+    ${json}=    Kubectl Output    get    xtrinode/${runtime}    -n    ${NAMESPACE}    -o    json
+    Create File    ${runtime_file}    ${json}
+    JQ Should Match    ${runtime_file}    any(.status.conditions[]; .type == $type and .status == $status and .reason == $reason and ((.message // "") | test($message_pattern)))    --arg    type    ${condition_type}    --arg    status    ${condition_status}    --arg    reason    ${reason}    --arg    message_pattern    ${message_pattern}
+
 Prepare Typed Runtime Shape Contract
     Cleanup Typed Runtime Shape Contract Objects
     ${node}=    Kubectl Output    get    nodes    -o    jsonpath={.items[0].metadata.name}
@@ -174,6 +214,29 @@ Cleanup Scheduling Blocker Contract Objects
     Run Command Allow Failure    kubectl    delete    xtrinode/${SCHEDULING_BLOCKED_NAME}    -n    ${NAMESPACE}    --wait=false    --ignore-not-found=true
     Run Command Allow Failure    kubectl    wait    xtrinode/${SCHEDULING_BLOCKED_NAME}    -n    ${NAMESPACE}    --for=delete    --timeout=120s
     Run Command Allow Failure    kubectl    delete    deployment,service,configmap,poddisruptionbudget,serviceaccount,horizontalpodautoscaler,scaledobject,triggerauthentication    -n    ${NAMESPACE}    -l    app.kubernetes.io/instance=${SCHEDULING_BLOCKED_NAME}    --ignore-not-found=true    --wait=false
+
+Prepare Taint Blocker Contract
+    Cleanup Taint Blocker Contract Objects
+    Command Should Succeed    kubectl    label    nodes    --all    ${TAINT_BLOCKED_NODE_LABEL}=${TAINT_BLOCKED_NODE_VALUE}    --overwrite
+    Command Should Succeed    kubectl    taint    nodes    --all    ${TAINT_BLOCKED_TAINT_KEY}=${TAINT_BLOCKED_TAINT_VALUE}:NoSchedule    --overwrite
+    ${manifest}=    Set Variable    /tmp/xtrinode-schedulability-taint-blocked.json
+    ${json}=    Set Variable    {"apiVersion":"analytics.xtrinode.io/v1","kind":"XTrinode","metadata":{"name":"${TAINT_BLOCKED_NAME}","namespace":"${NAMESPACE}","labels":{"test.xtrinode.io/contract":"schedulability-taint-blocked"}},"spec":{"size":"xs","minWorkers":1,"maxWorkers":1,"autoSuspendAfter":"30m","keda":{"enabled":false},"placement":{"nodeSelector":{"${TAINT_BLOCKED_NODE_LABEL}":"${TAINT_BLOCKED_NODE_VALUE}"}},"routing":{"header":"X-Trino-XTrinode=${NAMESPACE}/${TAINT_BLOCKED_NAME}","routingGroup":"schedulability-taint-blocked"},"valuesOverlay":{"image":{"repository":"${TRINO_IMAGE_REPOSITORY}","tag":"${TRINO_IMAGE_TAG}","pullPolicy":"IfNotPresent"}}}}
+    Create File    ${manifest}    ${json}
+    Command Should Succeed    kubectl    apply    -f    ${manifest}
+
+Cleanup Taint Blocker Contract Objects
+    Run Command Allow Failure    kubectl    patch    xtrinode/${TAINT_BLOCKED_NAME}    -n    ${NAMESPACE}    --type=merge    -p    {"metadata":{"finalizers":[]}}
+    Run Command Allow Failure    kubectl    delete    xtrinode/${TAINT_BLOCKED_NAME}    -n    ${NAMESPACE}    --wait=false    --ignore-not-found=true
+    Run Command Allow Failure    kubectl    wait    xtrinode/${TAINT_BLOCKED_NAME}    -n    ${NAMESPACE}    --for=delete    --timeout=120s
+    Run Command Allow Failure    kubectl    delete    deployment,service,configmap,poddisruptionbudget,serviceaccount,horizontalpodautoscaler,scaledobject,triggerauthentication    -n    ${NAMESPACE}    -l    app.kubernetes.io/instance=${TAINT_BLOCKED_NAME}    --ignore-not-found=true    --wait=false
+    Run Command Allow Failure    kubectl    taint    nodes    --all    ${TAINT_BLOCKED_TAINT_KEY}-
+    Run Command Allow Failure    kubectl    label    nodes    --all    ${TAINT_BLOCKED_NODE_LABEL}-    --overwrite
+
+Cleanup Capacity Blocker Contract Objects
+    Run Command Allow Failure    kubectl    patch    xtrinode/${CAPACITY_BLOCKED_NAME}    -n    ${NAMESPACE}    --type=merge    -p    {"metadata":{"finalizers":[]}}
+    Run Command Allow Failure    kubectl    delete    xtrinode/${CAPACITY_BLOCKED_NAME}    -n    ${NAMESPACE}    --wait=false    --ignore-not-found=true
+    Run Command Allow Failure    kubectl    wait    xtrinode/${CAPACITY_BLOCKED_NAME}    -n    ${NAMESPACE}    --for=delete    --timeout=120s
+    Run Command Allow Failure    kubectl    delete    deployment,service,configmap,poddisruptionbudget,serviceaccount,horizontalpodautoscaler,scaledobject,triggerauthentication    -n    ${NAMESPACE}    -l    app.kubernetes.io/instance=${CAPACITY_BLOCKED_NAME}    --ignore-not-found=true    --wait=false
 
 Cleanup KEDA Admission Contract Objects
     Run Command Allow Failure    kubectl    delete    scaledobject    invalid-memory-zero-contract    -n    ${NAMESPACE}    --ignore-not-found=true

--- a/xtrinode/controllers/finalizer_regression_test.go
+++ b/xtrinode/controllers/finalizer_regression_test.go
@@ -226,6 +226,43 @@ func TestCleanupResourcesRetainsNodePoolWhenPolicyRetain(t *testing.T) {
 	assert.Equal(t, 1, nodePoolAdapter.retainCalls)
 }
 
+func TestCleanupResourcesRetainsObservedNodePoolWhenSpecRemoved(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme()
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{Name: "runtime", Namespace: "team-a"},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size: "s",
+		},
+		Status: analyticsv1.XTrinodeStatus{
+			ObservedRuntimeShape: &analyticsv1.ObservedRuntimeShapeStatus{
+				Version: analyticsv1.ObservedRuntimeShapeStatusVersion,
+				NodePool: analyticsv1.ObservedRuntimeNodePoolStatus{
+					ProvisioningRequested: true,
+					Provider:              "gcp",
+					ProviderMode:          "managed",
+					Name:                  "runtime-pool",
+					SchedulePods:          true,
+					DeletionPolicy:        analyticsv1.NodePoolDeletionPolicyDelete,
+				},
+			},
+		},
+	}
+	reconciler := newTestReconciler(newTestClient(scheme, xtrinode), scheme)
+	reconciler.GatewayService = &gatewayServiceTestDouble{}
+	nodePoolAdapter := &recordingNodePoolAdapter{}
+	reconciler.NodePoolAdapter = nodePoolAdapter
+
+	err := reconciler.cleanupResources(ctx, xtrinode, newTestLogger())
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, nodePoolAdapter.deleteCalls)
+	assert.Equal(t, 1, nodePoolAdapter.retainCalls)
+	require.Len(t, nodePoolAdapter.retainedNodePools, 1)
+	assert.Equal(t, "runtime-pool", nodePoolAdapter.retainedNodePools[0].Name)
+	assert.Equal(t, analyticsv1.NodePoolDeletionPolicyRetain, nodePoolAdapter.retainedNodePools[0].DeletionPolicy)
+}
+
 func TestCleanupResourcesDeletesNodePoolWhenPolicyDelete(t *testing.T) {
 	ctx := context.Background()
 	scheme := newTestScheme()

--- a/xtrinode/controllers/nodepool_provisioning_diagnostics.go
+++ b/xtrinode/controllers/nodepool_provisioning_diagnostics.go
@@ -1,0 +1,350 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	analyticsv1 "github.com/xtrinode/xtrinode/api/v1"
+	"github.com/xtrinode/xtrinode/internal/config"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const maxNodePoolProvisioningDiagnosticMessageLen = 900
+
+type nodePoolProvisioningDiagnostic struct {
+	sourceKind    string
+	sourceName    string
+	conditionType string
+	reason        string
+	message       string
+}
+
+func (d *nodePoolProvisioningDiagnostic) statusMessage() string {
+	source := strings.TrimSpace(d.sourceKind + " " + d.sourceName)
+	parts := make([]string, 0, 3)
+	if d.conditionType != "" {
+		parts = append(parts, "condition="+d.conditionType)
+	}
+	if d.reason != "" {
+		parts = append(parts, "reason="+d.reason)
+	}
+	if d.message != "" {
+		parts = append(parts, d.message)
+	}
+	if len(parts) == 0 {
+		return truncateNodePoolProvisioningDiagnostic(source)
+	}
+	return truncateNodePoolProvisioningDiagnostic(source + " reported provisioning failure: " + strings.Join(parts, "; "))
+}
+
+func (r *XTrinodeReconciler) nodePoolProvisioningFailureDiagnostic(
+	ctx context.Context,
+	xtrinode *analyticsv1.XTrinode,
+	machineResource *unstructured.Unstructured,
+) (*nodePoolProvisioningDiagnostic, error) {
+	if diagnostic, ok := provisioningFailureFromObject(machineResource); ok {
+		return &diagnostic, nil
+	}
+
+	if infrastructureResource, ok, err := r.getNodePoolInfrastructureResource(ctx, xtrinode); err != nil {
+		return nil, err
+	} else if ok {
+		if diagnostic, found := provisioningFailureFromObject(infrastructureResource); found {
+			return &diagnostic, nil
+		}
+	}
+
+	relatedResources, err := r.relatedNodePoolProvisioningResources(ctx, xtrinode, machineResource)
+	if err != nil {
+		return nil, err
+	}
+	for i := range relatedResources {
+		if diagnostic, ok := provisioningFailureFromObject(relatedResources[i]); ok {
+			return &diagnostic, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *XTrinodeReconciler) getNodePoolInfrastructureResource(ctx context.Context, xtrinode *analyticsv1.XTrinode) (*unstructured.Unstructured, bool, error) {
+	nodePool := xtrinode.Spec.NodePool
+	if nodePool == nil {
+		return nil, false, nil
+	}
+
+	nodePoolName := getNodePoolName(nodePool, xtrinode.Name)
+	infrastructureName := nodePoolName + config.NodePoolTemplateSuffix
+	infrastructureGVK := getInfrastructureTemplateGVK(nodePool.Provider, isMachinePoolProvider(nodePool))
+	if nodePool.ProviderMode == "managed" {
+		infrastructureName = nodePoolName
+		infrastructureGVK = getManagedInfrastructureGVK(nodePool.Provider)
+	}
+
+	resource := &unstructured.Unstructured{}
+	resource.SetGroupVersionKind(infrastructureGVK)
+	err := r.Get(ctx, client.ObjectKey{Name: infrastructureName, Namespace: xtrinode.Namespace}, resource)
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("failed to inspect node-pool infrastructure resource %s/%s: %w", infrastructureGVK.Kind, infrastructureName, err)
+	}
+	return resource, true, nil
+}
+
+func (r *XTrinodeReconciler) relatedNodePoolProvisioningResources(
+	ctx context.Context,
+	xtrinode *analyticsv1.XTrinode,
+	machineResource *unstructured.Unstructured,
+) ([]*unstructured.Unstructured, error) {
+	machineSets, err := r.nodePoolMachineSets(ctx, xtrinode, machineResource)
+	if err != nil {
+		return nil, err
+	}
+	machines, err := r.nodePoolMachines(ctx, xtrinode, machineResource, machineSets)
+	if err != nil {
+		return nil, err
+	}
+
+	resources := make([]*unstructured.Unstructured, 0, len(machineSets)+len(machines)*2)
+	resources = append(resources, machineSets...)
+	resources = append(resources, machines...)
+	for _, machine := range machines {
+		infrastructureResource, ok, err := r.machineInfrastructureResource(ctx, machine)
+		if err != nil {
+			return resources, err
+		}
+		if ok {
+			resources = append(resources, infrastructureResource)
+		}
+	}
+	return resources, nil
+}
+
+func (r *XTrinodeReconciler) nodePoolMachineSets(
+	ctx context.Context,
+	xtrinode *analyticsv1.XTrinode,
+	machineResource *unstructured.Unstructured,
+) ([]*unstructured.Unstructured, error) {
+	if machineResource.GetKind() != "MachineDeployment" {
+		return nil, nil
+	}
+
+	machineSetList := newNodePoolUnstructuredList(machineSetGVK())
+	if err := r.List(ctx, machineSetList, client.InNamespace(xtrinode.Namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list node-pool MachineSets: %w", err)
+	}
+
+	machineSets := make([]*unstructured.Unstructured, 0)
+	for i := range machineSetList.Items {
+		machineSet := &machineSetList.Items[i]
+		if hasOwnerReferenceToObject(machineSet, machineResource) {
+			machineSets = append(machineSets, machineSet.DeepCopy())
+		}
+	}
+	return machineSets, nil
+}
+
+func (r *XTrinodeReconciler) nodePoolMachines(
+	ctx context.Context,
+	xtrinode *analyticsv1.XTrinode,
+	machineResource *unstructured.Unstructured,
+	machineSets []*unstructured.Unstructured,
+) ([]*unstructured.Unstructured, error) {
+	machineList := newNodePoolUnstructuredList(machineGVK())
+	if err := r.List(ctx, machineList, client.InNamespace(xtrinode.Namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list node-pool Machines: %w", err)
+	}
+
+	machines := make([]*unstructured.Unstructured, 0)
+	for i := range machineList.Items {
+		machine := &machineList.Items[i]
+		if hasOwnerReferenceToObject(machine, machineResource) || hasOwnerReferenceToAnyObject(machine, machineSets) {
+			machines = append(machines, machine.DeepCopy())
+		}
+	}
+	return machines, nil
+}
+
+func (r *XTrinodeReconciler) machineInfrastructureResource(ctx context.Context, machine *unstructured.Unstructured) (*unstructured.Unstructured, bool, error) {
+	ref, found, err := unstructured.NestedMap(machine.Object, "spec", "infrastructureRef")
+	if err != nil || !found {
+		return nil, false, nil
+	}
+
+	apiVersion, ok := ref["apiVersion"].(string)
+	if !ok || apiVersion == "" {
+		return nil, false, nil
+	}
+	kind, ok := ref["kind"].(string)
+	if !ok || kind == "" {
+		return nil, false, nil
+	}
+	name, ok := ref["name"].(string)
+	if !ok || name == "" {
+		return nil, false, nil
+	}
+	namespace, _ := ref["namespace"].(string) //nolint:errcheck // optional field; absence falls back to the Machine namespace
+	if namespace == "" {
+		namespace = machine.GetNamespace()
+	}
+	groupVersion, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return nil, false, nil
+	}
+
+	resource := &unstructured.Unstructured{}
+	resource.SetGroupVersionKind(groupVersion.WithKind(kind))
+	err = r.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, resource)
+	if err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("failed to inspect Machine infrastructure resource %s/%s: %w", kind, name, err)
+	}
+	return resource, true, nil
+}
+
+func provisioningFailureFromObject(obj *unstructured.Unstructured) (nodePoolProvisioningDiagnostic, bool) {
+	statusMap, found, err := unstructured.NestedMap(obj.Object, "status")
+	if err != nil || !found {
+		return nodePoolProvisioningDiagnostic{}, false
+	}
+
+	if diagnostic, ok := objectFailureFieldsDiagnostic(obj, statusMap); ok {
+		return diagnostic, true
+	}
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return nodePoolProvisioningDiagnostic{}, false
+	}
+	for _, rawCondition := range conditions {
+		condition, ok := rawCondition.(map[string]interface{})
+		if !ok || !conditionReportsProvisioningFailure(condition) {
+			continue
+		}
+		return nodePoolProvisioningDiagnostic{
+			sourceKind:    obj.GetKind(),
+			sourceName:    obj.GetName(),
+			conditionType: conditionString(condition, "type"),
+			reason:        conditionString(condition, "reason"),
+			message:       conditionString(condition, "message"),
+		}, true
+	}
+	return nodePoolProvisioningDiagnostic{}, false
+}
+
+func objectFailureFieldsDiagnostic(obj *unstructured.Unstructured, statusMap map[string]interface{}) (nodePoolProvisioningDiagnostic, bool) {
+	reason := stringField(statusMap, "failureReason")
+	message := stringField(statusMap, "failureMessage")
+	if reason == "" && message == "" {
+		return nodePoolProvisioningDiagnostic{}, false
+	}
+	return nodePoolProvisioningDiagnostic{
+		sourceKind: obj.GetKind(),
+		sourceName: obj.GetName(),
+		reason:     reason,
+		message:    message,
+	}, true
+}
+
+func conditionReportsProvisioningFailure(condition map[string]interface{}) bool {
+	conditionStatus := strings.ToLower(conditionString(condition, "status"))
+	conditionType := conditionString(condition, "type")
+	severity := strings.ToLower(conditionString(condition, "severity"))
+	conditionTypeText := strings.ToLower(conditionType)
+	detailText := strings.ToLower(conditionString(condition, "reason") + " " + conditionString(condition, "message"))
+
+	if conditionStatus == "true" && containsAnySchedulingPhrase(conditionTypeText+" "+detailText, "failed", "failure", "error") {
+		return true
+	}
+	if severity == "error" && conditionStatus != "true" {
+		return true
+	}
+	if conditionStatus == "false" || conditionStatus == "unknown" {
+		return containsNodePoolFailurePhrase(detailText)
+	}
+	return false
+}
+
+func containsNodePoolFailurePhrase(text string) bool {
+	return containsAnySchedulingPhrase(
+		text,
+		"fail",
+		"error",
+		"invalid",
+		"denied",
+		"forbidden",
+		"unauthoriz",
+		"quota",
+		"capacity",
+		"insufficient",
+		"exceeded",
+		"not found",
+		"notfound",
+		"timeout",
+		"timed out",
+		"unable",
+		"cannot",
+	)
+}
+
+func conditionString(condition map[string]interface{}, key string) string {
+	return stringField(condition, key)
+}
+
+func stringField(fields map[string]interface{}, key string) string {
+	value, ok := fields[key].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}
+
+func machineGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "cluster.x-k8s.io", Version: "v1beta1", Kind: "Machine"}
+}
+
+func machineSetGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "cluster.x-k8s.io", Version: "v1beta1", Kind: "MachineSet"}
+}
+
+func newNodePoolUnstructuredList(gvk schema.GroupVersionKind) *unstructured.UnstructuredList {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(gvk.GroupVersion().WithKind(gvk.Kind + "List"))
+	return list
+}
+
+func hasOwnerReferenceToAnyObject(obj *unstructured.Unstructured, owners []*unstructured.Unstructured) bool {
+	for _, owner := range owners {
+		if hasOwnerReferenceToObject(obj, owner) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasOwnerReferenceToObject(obj, owner *unstructured.Unstructured) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.APIVersion != owner.GetAPIVersion() || ref.Kind != owner.GetKind() || ref.Name != owner.GetName() {
+			continue
+		}
+		if ref.UID != "" && owner.GetUID() != "" && ref.UID != owner.GetUID() {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func truncateNodePoolProvisioningDiagnostic(message string) string {
+	message = strings.Join(strings.Fields(message), " ")
+	runes := []rune(message)
+	if len(runes) <= maxNodePoolProvisioningDiagnosticMessageLen {
+		return message
+	}
+	return string(runes[:maxNodePoolProvisioningDiagnosticMessageLen]) + "..."
+}

--- a/xtrinode/controllers/nodepool_readiness_test.go
+++ b/xtrinode/controllers/nodepool_readiness_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 	analyticsv1 "github.com/xtrinode/xtrinode/api/v1"
 	"github.com/xtrinode/xtrinode/internal/config"
+	"github.com/xtrinode/xtrinode/internal/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -120,6 +122,178 @@ func TestWaitForNodePoolReady(t *testing.T) {
 	}
 }
 
+func TestWaitForNodePoolReadyReportsCoreFailureCondition(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestSchemeAnalyticsOnly()
+	xtrinode := testReadinessXTrinode(
+		&analyticsv1.NodePoolSpec{
+			Provider: "aws",
+			AWS:      &analyticsv1.AWSNodePoolSpec{InstanceType: "m5.xlarge"},
+		},
+	)
+	resource := testReadinessResource("runtime", "team-a", map[string]interface{}{
+		"readyReplicas": int64(0),
+		"replicas":      int64(1),
+		"conditions": []interface{}{
+			map[string]interface{}{
+				"type":     "Ready",
+				"status":   "False",
+				"severity": "Error",
+				"reason":   "InstanceProvisionFailed",
+				"message":  "cloud quota exceeded",
+			},
+		},
+	})
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(xtrinode).
+		WithStatusSubresource(&analyticsv1.XTrinode{}).
+		WithRuntimeObjects(resource).
+		Build()
+	reconciler := newTestReconciler(cli, scheme)
+
+	ready, result, err := reconciler.waitForNodePoolReady(ctx, xtrinode, newTestLogger())
+
+	require.NoError(t, err)
+	assert.False(t, ready)
+	assert.Equal(t, config.NodePoolProvisioningErrorRequeueInterval, result.RequeueAfter)
+	stored := &analyticsv1.XTrinode{}
+	require.NoError(t, cli.Get(ctx, types.NamespacedName{Name: "runtime", Namespace: "team-a"}, stored))
+	condition := status.GetCondition(stored, status.ConditionTypeNodePoolReady)
+	require.NotNil(t, condition)
+	assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	assert.Equal(t, status.ConditionReasonNodePoolFailed, condition.Reason)
+	assert.Contains(t, condition.Message, "MachineDeployment")
+	assert.Contains(t, condition.Message, "InstanceProvisionFailed")
+	assert.Contains(t, condition.Message, "cloud quota exceeded")
+}
+
+func TestWaitForNodePoolReadyReportsManagedProviderFailureCondition(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestSchemeAnalyticsOnly()
+	xtrinode := testReadinessXTrinode(
+		&analyticsv1.NodePoolSpec{
+			Provider:     "gcp",
+			ProviderMode: "managed",
+			GCP:          &analyticsv1.GCPNodePoolSpec{MachineType: "e2-standard-4"},
+		},
+	)
+	machinePool := testReadinessResourceWithGVK(
+		getMachineResourceGVK(true),
+		"runtime"+config.NodePoolNameSuffix,
+		"team-a",
+		map[string]interface{}{"readyReplicas": int64(0), "replicas": int64(1)},
+	)
+	managedPool := testReadinessResourceWithGVK(
+		getManagedInfrastructureGVK("gcp"),
+		"runtime"+config.NodePoolNameSuffix,
+		"team-a",
+		map[string]interface{}{
+			"conditions": []interface{}{
+				map[string]interface{}{
+					"type":    "Ready",
+					"status":  "False",
+					"reason":  "GKENodePoolCreateFailed",
+					"message": "GKE rejected the node pool request",
+				},
+			},
+		},
+	)
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(xtrinode).
+		WithStatusSubresource(&analyticsv1.XTrinode{}).
+		WithRuntimeObjects(machinePool, managedPool).
+		Build()
+	reconciler := newTestReconciler(cli, scheme)
+
+	ready, result, err := reconciler.waitForNodePoolReady(ctx, xtrinode, newTestLogger())
+
+	require.NoError(t, err)
+	assert.False(t, ready)
+	assert.Equal(t, config.NodePoolProvisioningErrorRequeueInterval, result.RequeueAfter)
+	stored := &analyticsv1.XTrinode{}
+	require.NoError(t, cli.Get(ctx, types.NamespacedName{Name: "runtime", Namespace: "team-a"}, stored))
+	condition := status.GetCondition(stored, status.ConditionTypeNodePoolReady)
+	require.NotNil(t, condition)
+	assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	assert.Contains(t, condition.Message, "GCPManagedMachinePool")
+	assert.Contains(t, condition.Message, "GKENodePoolCreateFailed")
+}
+
+func TestWaitForNodePoolReadyReportsMachineInfrastructureRefFailure(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestSchemeAnalyticsOnly()
+	xtrinode := testReadinessXTrinode(
+		&analyticsv1.NodePoolSpec{
+			Provider: "aws",
+			AWS:      &analyticsv1.AWSNodePoolSpec{InstanceType: "m5.xlarge"},
+		},
+	)
+	machineDeployment := testReadinessResource("runtime", "team-a", map[string]interface{}{
+		"readyReplicas": int64(0),
+		"replicas":      int64(1),
+	})
+	machineDeployment.SetUID(types.UID("md-uid"))
+	machineSet := testReadinessResourceWithGVK(machineSetGVK(), "runtime-pool-ms", "team-a", nil)
+	machineSet.SetUID(types.UID("ms-uid"))
+	machineSet.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion: machineDeployment.GetAPIVersion(),
+			Kind:       machineDeployment.GetKind(),
+			Name:       machineDeployment.GetName(),
+			UID:        machineDeployment.GetUID(),
+		},
+	})
+	machine := testReadinessResourceWithGVK(machineGVK(), "runtime-machine-1", "team-a", map[string]interface{}{})
+	machine.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion: machineSet.GetAPIVersion(),
+			Kind:       machineSet.GetKind(),
+			Name:       machineSet.GetName(),
+			UID:        machineSet.GetUID(),
+		},
+	})
+	machine.Object["spec"] = map[string]interface{}{
+		"infrastructureRef": map[string]interface{}{
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta2",
+			"kind":       "AWSMachine",
+			"name":       "runtime-machine-1",
+			"namespace":  "team-a",
+		},
+	}
+	awsMachine := testReadinessResourceWithGVK(
+		schema.GroupVersionKind{Group: "infrastructure.cluster.x-k8s.io", Version: "v1beta2", Kind: "AWSMachine"},
+		"runtime-machine-1",
+		"team-a",
+		map[string]interface{}{
+			"failureReason":  "InstanceLaunchFailed",
+			"failureMessage": "EC2 quota exceeded",
+		},
+	)
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(xtrinode).
+		WithStatusSubresource(&analyticsv1.XTrinode{}).
+		WithRuntimeObjects(machineDeployment, machineSet, machine, awsMachine).
+		Build()
+	reconciler := newTestReconciler(cli, scheme)
+
+	ready, result, err := reconciler.waitForNodePoolReady(ctx, xtrinode, newTestLogger())
+
+	require.NoError(t, err)
+	assert.False(t, ready)
+	assert.Equal(t, config.NodePoolProvisioningErrorRequeueInterval, result.RequeueAfter)
+	stored := &analyticsv1.XTrinode{}
+	require.NoError(t, cli.Get(ctx, types.NamespacedName{Name: "runtime", Namespace: "team-a"}, stored))
+	condition := status.GetCondition(stored, status.ConditionTypeNodePoolReady)
+	require.NotNil(t, condition)
+	assert.Equal(t, metav1.ConditionFalse, condition.Status)
+	assert.Contains(t, condition.Message, "AWSMachine")
+	assert.Contains(t, condition.Message, "InstanceLaunchFailed")
+	assert.Contains(t, condition.Message, "EC2 quota exceeded")
+}
+
 func testReadinessXTrinode(nodePool *analyticsv1.NodePoolSpec) *analyticsv1.XTrinode {
 	return &analyticsv1.XTrinode{
 		ObjectMeta: metav1.ObjectMeta{Name: "runtime", Namespace: "team-a"},
@@ -130,17 +304,26 @@ func testReadinessXTrinode(nodePool *analyticsv1.NodePoolSpec) *analyticsv1.XTri
 	}
 }
 
-func testReadinessResource(xtrinodeName, namespace string, status map[string]interface{}) *unstructured.Unstructured {
+func testReadinessResource(xtrinodeName, namespace string, resourceStatus map[string]interface{}) *unstructured.Unstructured {
+	return testReadinessResourceWithGVK(
+		schema.GroupVersionKind{
+			Group:   "cluster.x-k8s.io",
+			Version: "v1beta1",
+			Kind:    "MachineDeployment",
+		},
+		xtrinodeName+config.NodePoolNameSuffix,
+		namespace,
+		resourceStatus,
+	)
+}
+
+func testReadinessResourceWithGVK(gvk schema.GroupVersionKind, name, namespace string, resourceStatus map[string]interface{}) *unstructured.Unstructured {
 	resource := &unstructured.Unstructured{}
-	resource.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "cluster.x-k8s.io",
-		Version: "v1beta1",
-		Kind:    "MachineDeployment",
-	})
-	resource.SetName(xtrinodeName + config.NodePoolNameSuffix)
+	resource.SetGroupVersionKind(gvk)
+	resource.SetName(name)
 	resource.SetNamespace(namespace)
-	if status != nil {
-		resource.Object["status"] = status
+	if resourceStatus != nil {
+		resource.Object["status"] = resourceStatus
 	}
 	return resource
 }

--- a/xtrinode/controllers/runtime_readiness.go
+++ b/xtrinode/controllers/runtime_readiness.go
@@ -135,6 +135,7 @@ func (r *XTrinodeReconciler) syncSchedulingCondition(ctx context.Context, xtrino
 			blockers.add(reason, message, fmt.Sprintf("%s deployment %s: %s: %s", component, deployment.Name, reason, message))
 		}
 	}
+	r.addClusterSchedulingDiagnostics(ctx, &blockers, pods.Items, log)
 	if blockers.hasAny() {
 		setSchedulingBlockedConditions(xtrinode, &blockers)
 		return

--- a/xtrinode/controllers/runtime_readiness_test.go
+++ b/xtrinode/controllers/runtime_readiness_test.go
@@ -15,6 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -67,7 +68,12 @@ func TestSyncSchedulingConditionReportsUnschedulablePod(t *testing.T) {
 			},
 		},
 	}
-	reconciler := newRuntimeReadinessReconciler(t, xtrinode, pod)
+	node := testReadySchedulingNode("node-a", nil, corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("4"),
+		corev1.ResourceMemory: resource.MustParse("16Gi"),
+		corev1.ResourcePods:   resource.MustParse("20"),
+	})
+	reconciler := newRuntimeReadinessReconciler(t, xtrinode, pod, node)
 
 	reconciler.syncSchedulingCondition(context.Background(), xtrinode, newTestLogger())
 
@@ -108,7 +114,12 @@ func TestSyncSchedulingConditionClassifiesPlacementAndTaintBlockers(t *testing.T
 			},
 		},
 	}
-	reconciler := newRuntimeReadinessReconciler(t, xtrinode, pod)
+	node := testReadySchedulingNode("node-a", nil, corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("4"),
+		corev1.ResourceMemory: resource.MustParse("16Gi"),
+		corev1.ResourcePods:   resource.MustParse("20"),
+	})
+	reconciler := newRuntimeReadinessReconciler(t, xtrinode, pod, node)
 
 	reconciler.syncSchedulingCondition(context.Background(), xtrinode, newTestLogger())
 
@@ -151,6 +162,98 @@ func TestSyncSchedulingConditionReportsQuotaReplicaFailures(t *testing.T) {
 	require.Equal(t, metav1.ConditionFalse, quotaCondition.Status)
 	require.Equal(t, status.ConditionReasonQuotaBlocked, quotaCondition.Reason)
 	require.Contains(t, quotaCondition.Message, "exceeded quota")
+}
+
+func TestSyncSchedulingConditionAddsNodeSelectorDiagnostics(t *testing.T) {
+	xtrinode := testRuntimeReadinessXTrinode(nil)
+	pod := testPendingRuntimePod(xtrinode, "runtime-worker-0", corev1.ResourceList{})
+	pod.Spec.NodeSelector = map[string]string{"disk": "ssd"}
+	node := testReadySchedulingNode("node-a", map[string]string{"disk": "hdd"}, corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("4"),
+		corev1.ResourceMemory: resource.MustParse("16Gi"),
+		corev1.ResourcePods:   resource.MustParse("20"),
+	})
+	reconciler := newRuntimeReadinessReconciler(t, pod, node)
+
+	reconciler.syncSchedulingCondition(context.Background(), xtrinode, newTestLogger())
+
+	placementCondition := status.GetCondition(xtrinode, status.ConditionTypePlacementReady)
+	require.NotNil(t, placementCondition)
+	require.Equal(t, metav1.ConditionFalse, placementCondition.Status)
+	require.Equal(t, status.ConditionReasonPlacementBlocked, placementCondition.Reason)
+	require.Contains(t, placementCondition.Message, "node selector")
+}
+
+func TestSyncSchedulingConditionTreatsEmptyRequiredNodeSelectorTermAsNoMatch(t *testing.T) {
+	xtrinode := testRuntimeReadinessXTrinode(nil)
+	pod := testPendingRuntimePod(xtrinode, "runtime-worker-0", corev1.ResourceList{})
+	pod.Spec.Affinity = &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{{}},
+			},
+		},
+	}
+	node := testReadySchedulingNode("node-a", nil, corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("4"),
+		corev1.ResourceMemory: resource.MustParse("16Gi"),
+		corev1.ResourcePods:   resource.MustParse("20"),
+	})
+	reconciler := newRuntimeReadinessReconciler(t, pod, node)
+
+	reconciler.syncSchedulingCondition(context.Background(), xtrinode, newTestLogger())
+
+	placementCondition := status.GetCondition(xtrinode, status.ConditionTypePlacementReady)
+	require.NotNil(t, placementCondition)
+	require.Equal(t, metav1.ConditionFalse, placementCondition.Status)
+	require.Equal(t, status.ConditionReasonPlacementBlocked, placementCondition.Reason)
+}
+
+func TestSyncSchedulingConditionAddsTaintDiagnostics(t *testing.T) {
+	xtrinode := testRuntimeReadinessXTrinode(nil)
+	pod := testPendingRuntimePod(xtrinode, "runtime-worker-0", corev1.ResourceList{})
+	node := testReadySchedulingNode("node-a", nil, corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("4"),
+		corev1.ResourceMemory: resource.MustParse("16Gi"),
+		corev1.ResourcePods:   resource.MustParse("20"),
+	})
+	node.Spec.Taints = []corev1.Taint{
+		{Key: "dedicated", Value: "analytics", Effect: corev1.TaintEffectNoSchedule},
+	}
+	reconciler := newRuntimeReadinessReconciler(t, pod, node)
+
+	reconciler.syncSchedulingCondition(context.Background(), xtrinode, newTestLogger())
+
+	taintsCondition := status.GetCondition(xtrinode, status.ConditionTypeTaintsReady)
+	require.NotNil(t, taintsCondition)
+	require.Equal(t, metav1.ConditionFalse, taintsCondition.Status)
+	require.Equal(t, status.ConditionReasonTaintsBlocked, taintsCondition.Reason)
+	require.Contains(t, taintsCondition.Message, "untolerated")
+}
+
+func TestSyncSchedulingConditionAccountsForDaemonSetOverhead(t *testing.T) {
+	xtrinode := testRuntimeReadinessXTrinode(nil)
+	pod := testPendingRuntimePod(xtrinode, "runtime-worker-0", corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse("900m"),
+	})
+	node := testReadySchedulingNode("node-a", nil, corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("1"),
+		corev1.ResourceMemory: resource.MustParse("16Gi"),
+		corev1.ResourcePods:   resource.MustParse("20"),
+	})
+	daemonSet := testSchedulingDaemonSet("node-agent", "kube-system", corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse("200m"),
+	})
+	reconciler := newRuntimeReadinessReconciler(t, pod, node, daemonSet)
+
+	reconciler.syncSchedulingCondition(context.Background(), xtrinode, newTestLogger())
+
+	capacityCondition := status.GetCondition(xtrinode, status.ConditionTypeCapacityReady)
+	require.NotNil(t, capacityCondition)
+	require.Equal(t, metav1.ConditionFalse, capacityCondition.Status)
+	require.Equal(t, status.ConditionReasonCapacityBlocked, capacityCondition.Reason)
+	require.Contains(t, capacityCondition.Message, "DaemonSet overhead")
+	require.Contains(t, capacityCondition.Message, "bestAvailable=cpu=800m")
 }
 
 func TestCheckTrinoRuntimeReadyRequiresWorkerFloor(t *testing.T) {
@@ -425,6 +528,76 @@ func testRuntimeReadinessEndpoint(xtrinode *analyticsv1.XTrinode) *discoveryv1.E
 		},
 		Ports: []discoveryv1.EndpointPort{
 			{Name: stringPtr("http"), Port: int32Ptr(config.TrinoPortHTTP)},
+		},
+	}
+}
+
+func testPendingRuntimePod(xtrinode *analyticsv1.XTrinode, name string, requests corev1.ResourceList) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: xtrinode.Namespace,
+			Labels:    trinoresources.TrinoSelectorLabels(xtrinode, trinoresources.ComponentWorker),
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "trino",
+					Resources: corev1.ResourceRequirements{
+						Requests: requests,
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+		},
+	}
+}
+
+func testReadySchedulingNode(name string, labels map[string]string, allocatable corev1.ResourceList) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: allocatable,
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+func testSchedulingDaemonSet(name, namespace string, requests corev1.ResourceList) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": name},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: name,
+							Resources: corev1.ResourceRequirements{
+								Requests: requests,
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/xtrinode/controllers/runtime_scheduling_diagnostics.go
+++ b/xtrinode/controllers/runtime_scheduling_diagnostics.go
@@ -1,0 +1,483 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const maxClusterSchedulingDiagnosticPods = 5
+
+func (r *XTrinodeReconciler) addClusterSchedulingDiagnostics(ctx context.Context, blockers *schedulingBlockerSet, runtimePods []corev1.Pod, log logr.Logger) {
+	pendingPods := pendingRuntimePods(runtimePods)
+	if len(pendingPods) == 0 {
+		return
+	}
+	if len(pendingPods) > maxClusterSchedulingDiagnosticPods {
+		log.Info("Truncating runtime pod scheduling diagnostics", "pods", len(pendingPods), "limit", maxClusterSchedulingDiagnosticPods)
+		pendingPods = pendingPods[:maxClusterSchedulingDiagnosticPods]
+	}
+
+	nodes := &corev1.NodeList{}
+	if err := r.List(ctx, nodes); err != nil {
+		log.Error(err, "failed to list nodes for runtime scheduling diagnostics")
+		return
+	}
+	if len(nodes.Items) == 0 {
+		for i := range pendingPods {
+			blockers.addCapacityDiagnostic(fmt.Sprintf("runtime pod %s: no cluster nodes are available for scheduling diagnostics", pendingPods[i].Name))
+		}
+		return
+	}
+
+	pods := &corev1.PodList{}
+	if err := r.List(ctx, pods); err != nil {
+		log.Error(err, "failed to list cluster pods for runtime scheduling diagnostics")
+		return
+	}
+
+	daemonSets := &appsv1.DaemonSetList{}
+	if err := r.List(ctx, daemonSets); err != nil {
+		log.Error(err, "failed to list DaemonSets for runtime scheduling diagnostics")
+		daemonSets = &appsv1.DaemonSetList{}
+	}
+
+	nodeStates := buildSchedulingNodeStates(nodes.Items, pods.Items, daemonSets.Items)
+	for i := range pendingPods {
+		addPodSchedulingDiagnostics(blockers, &pendingPods[i], nodeStates)
+	}
+}
+
+func pendingRuntimePods(pods []corev1.Pod) []corev1.Pod {
+	pendingPods := make([]corev1.Pod, 0)
+	for i := range pods {
+		pod := pods[i]
+		if podTerminated(&pod) || pod.Spec.NodeName != "" {
+			continue
+		}
+		if pod.Status.Phase == corev1.PodPending || hasUnscheduledCondition(&pod) {
+			pendingPods = append(pendingPods, pod)
+		}
+	}
+	return pendingPods
+}
+
+func hasUnscheduledCondition(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionFalse {
+			return true
+		}
+	}
+	return false
+}
+
+type schedulingNodeState struct {
+	node     *corev1.Node
+	free     corev1.ResourceList
+	freePods int64
+}
+
+func buildSchedulingNodeStates(nodes []corev1.Node, pods []corev1.Pod, daemonSets []appsv1.DaemonSet) []schedulingNodeState {
+	states := make([]schedulingNodeState, 0, len(nodes))
+	daemonSetPodsByNode := daemonSetPodsByNode(pods)
+
+	for i := range nodes {
+		node := &nodes[i]
+		if !nodeReadyForScheduling(node) {
+			continue
+		}
+		state := schedulingNodeState{
+			node:     node,
+			free:     copyResourceListForScheduling(node.Status.Allocatable),
+			freePods: allocatablePods(node),
+		}
+
+		for j := range pods {
+			pod := &pods[j]
+			if pod.Spec.NodeName != node.Name || podTerminated(pod) {
+				continue
+			}
+			subtractSchedulingRequests(state.free, podSchedulingRequests(&pod.Spec))
+			if state.freePods > 0 {
+				state.freePods--
+			}
+		}
+
+		for j := range daemonSets {
+			daemonSet := &daemonSets[j]
+			if !daemonSetShouldRunOnNode(daemonSet, node) || daemonSetPodsByNode.has(node.Name, daemonSet.Namespace, daemonSet.Name) {
+				continue
+			}
+			subtractSchedulingRequests(state.free, podSchedulingRequests(&daemonSet.Spec.Template.Spec))
+			if state.freePods > 0 {
+				state.freePods--
+			}
+		}
+
+		states = append(states, state)
+	}
+	return states
+}
+
+type daemonSetPodIndex map[string]map[string]struct{}
+
+func daemonSetPodsByNode(pods []corev1.Pod) daemonSetPodIndex {
+	index := daemonSetPodIndex{}
+	for i := range pods {
+		pod := &pods[i]
+		if pod.Spec.NodeName == "" || podTerminated(pod) {
+			continue
+		}
+		for _, owner := range pod.OwnerReferences {
+			if owner.APIVersion == "apps/v1" && owner.Kind == "DaemonSet" {
+				nodePods := index[pod.Spec.NodeName]
+				if nodePods == nil {
+					nodePods = map[string]struct{}{}
+					index[pod.Spec.NodeName] = nodePods
+				}
+				nodePods[pod.Namespace+"/"+owner.Name] = struct{}{}
+			}
+		}
+	}
+	return index
+}
+
+func (i daemonSetPodIndex) has(nodeName, namespace, name string) bool {
+	if i == nil {
+		return false
+	}
+	nodePods := i[nodeName]
+	if nodePods == nil {
+		return false
+	}
+	_, ok := nodePods[namespace+"/"+name]
+	return ok
+}
+
+func addPodSchedulingDiagnostics(blockers *schedulingBlockerSet, pod *corev1.Pod, nodeStates []schedulingNodeState) {
+	if len(nodeStates) == 0 {
+		blockers.addCapacityDiagnostic(fmt.Sprintf("runtime pod %s: no Ready schedulable nodes are available", pod.Name))
+		return
+	}
+
+	placementCandidates := make([]schedulingNodeState, 0, len(nodeStates))
+	for _, state := range nodeStates {
+		if podMatchesNodePlacement(pod, state.node) {
+			placementCandidates = append(placementCandidates, state)
+		}
+	}
+	if len(placementCandidates) == 0 {
+		blockers.addPlacementDiagnostic(fmt.Sprintf("runtime pod %s: no Ready schedulable nodes match node selector or required node affinity", pod.Name))
+		return
+	}
+
+	taintCandidates := make([]schedulingNodeState, 0, len(placementCandidates))
+	for _, state := range placementCandidates {
+		if podToleratesNodeTaints(&pod.Spec, state.node.Spec.Taints) {
+			taintCandidates = append(taintCandidates, state)
+		}
+	}
+	if len(taintCandidates) == 0 {
+		blockers.addTaintDiagnostic(fmt.Sprintf("runtime pod %s: matching nodes only have untolerated NoSchedule or NoExecute taints", pod.Name))
+		return
+	}
+
+	requests := podSchedulingRequests(&pod.Spec)
+	for _, state := range taintCandidates {
+		if schedulingRequestsFit(requests, state.free, state.freePods) {
+			return
+		}
+	}
+	blockers.addCapacityDiagnostic(fmt.Sprintf(
+		"runtime pod %s: insufficient allocatable capacity or pod slots after scheduled pods and DaemonSet overhead; requests=%s bestAvailable=%s",
+		pod.Name,
+		schedulingRequestsString(requests, 1),
+		bestAvailableSchedulingCapacity(taintCandidates),
+	))
+}
+
+func nodeReadyForScheduling(node *corev1.Node) bool {
+	if node.Spec.Unschedulable {
+		return false
+	}
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func podMatchesNodePlacement(pod *corev1.Pod, node *corev1.Node) bool {
+	for key, value := range pod.Spec.NodeSelector {
+		if node.Labels[key] != value {
+			return false
+		}
+	}
+	return requiredNodeAffinityMatches(pod.Spec.Affinity, node)
+}
+
+func requiredNodeAffinityMatches(affinity *corev1.Affinity, node *corev1.Node) bool {
+	if affinity == nil || affinity.NodeAffinity == nil || affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		return true
+	}
+	selector := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	for _, term := range selector.NodeSelectorTerms {
+		if nodeSelectorTermMatches(term, node) {
+			return true
+		}
+	}
+	return false
+}
+
+func nodeSelectorTermMatches(term corev1.NodeSelectorTerm, node *corev1.Node) bool {
+	if len(term.MatchExpressions) == 0 && len(term.MatchFields) == 0 {
+		return false
+	}
+	for _, expression := range term.MatchExpressions {
+		if !nodeSelectorRequirementMatches(expression, node.Labels) {
+			return false
+		}
+	}
+	for _, field := range term.MatchFields {
+		if !nodeFieldRequirementMatches(field, node) {
+			return false
+		}
+	}
+	return true
+}
+
+func nodeSelectorRequirementMatches(requirement corev1.NodeSelectorRequirement, nodeLabels map[string]string) bool {
+	value, exists := nodeLabels[requirement.Key]
+	switch requirement.Operator {
+	case corev1.NodeSelectorOpIn:
+		return exists && stringInSlice(value, requirement.Values)
+	case corev1.NodeSelectorOpNotIn:
+		return !exists || !stringInSlice(value, requirement.Values)
+	case corev1.NodeSelectorOpExists:
+		return exists
+	case corev1.NodeSelectorOpDoesNotExist:
+		return !exists
+	case corev1.NodeSelectorOpGt, corev1.NodeSelectorOpLt:
+		if !exists || len(requirement.Values) != 1 {
+			return false
+		}
+		nodeValue, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return false
+		}
+		requiredValue, err := strconv.ParseInt(requirement.Values[0], 10, 64)
+		if err != nil {
+			return false
+		}
+		if requirement.Operator == corev1.NodeSelectorOpGt {
+			return nodeValue > requiredValue
+		}
+		return nodeValue < requiredValue
+	default:
+		return false
+	}
+}
+
+func nodeFieldRequirementMatches(requirement corev1.NodeSelectorRequirement, node *corev1.Node) bool {
+	if requirement.Key != "metadata.name" {
+		return false
+	}
+	return nodeSelectorRequirementMatches(requirement, map[string]string{"metadata.name": node.Name})
+}
+
+func podToleratesNodeTaints(podSpec *corev1.PodSpec, taints []corev1.Taint) bool {
+	for _, taint := range taints {
+		if taint.Effect != corev1.TaintEffectNoSchedule && taint.Effect != corev1.TaintEffectNoExecute {
+			continue
+		}
+		tolerated := false
+		for _, toleration := range podSpec.Tolerations {
+			if toleration.ToleratesTaint(&taint) {
+				tolerated = true
+				break
+			}
+		}
+		if !tolerated {
+			return false
+		}
+	}
+	return true
+}
+
+func daemonSetShouldRunOnNode(daemonSet *appsv1.DaemonSet, node *corev1.Node) bool {
+	selector, err := metav1LabelSelectorAsSelector(daemonSet.Spec.Selector)
+	if err != nil || !selector.Matches(labels.Set(daemonSet.Spec.Template.Labels)) {
+		return false
+	}
+	templatePod := corev1.Pod{Spec: daemonSet.Spec.Template.Spec}
+	return podMatchesNodePlacement(&templatePod, node) && podToleratesNodeTaints(&templatePod.Spec, node.Spec.Taints)
+}
+
+func metav1LabelSelectorAsSelector(selector *metav1.LabelSelector) (labels.Selector, error) {
+	if selector == nil {
+		return labels.Nothing(), nil
+	}
+	return metav1.LabelSelectorAsSelector(selector)
+}
+
+func podSchedulingRequests(podSpec *corev1.PodSpec) corev1.ResourceList {
+	requests := corev1.ResourceList{}
+	for i := range podSpec.Containers {
+		addSchedulingRequests(requests, podSpec.Containers[i].Resources.Requests)
+	}
+	initRequests := corev1.ResourceList{}
+	for i := range podSpec.InitContainers {
+		keepLargerSchedulingRequests(initRequests, podSpec.InitContainers[i].Resources.Requests)
+	}
+	keepLargerSchedulingRequests(requests, initRequests)
+	addSchedulingRequests(requests, podSpec.Overhead)
+	return requests
+}
+
+func addSchedulingRequests(total, add corev1.ResourceList) {
+	for _, resourceName := range schedulingResourceNames() {
+		quantity := add[resourceName]
+		if quantity.Sign() == 0 {
+			continue
+		}
+		current := total[resourceName]
+		current.Add(quantity)
+		total[resourceName] = current
+	}
+}
+
+func keepLargerSchedulingRequests(total, candidate corev1.ResourceList) {
+	for _, resourceName := range schedulingResourceNames() {
+		quantity := candidate[resourceName]
+		if quantity.Sign() == 0 {
+			continue
+		}
+		current := total[resourceName]
+		if quantity.Cmp(current) > 0 {
+			total[resourceName] = quantity.DeepCopy()
+		}
+	}
+}
+
+func subtractSchedulingRequests(total, used corev1.ResourceList) {
+	for _, resourceName := range schedulingResourceNames() {
+		quantity := used[resourceName]
+		if quantity.Sign() == 0 {
+			continue
+		}
+		current := total[resourceName]
+		current.Sub(quantity)
+		total[resourceName] = current
+	}
+}
+
+func schedulingRequestsFit(requests, free corev1.ResourceList, freePods int64) bool {
+	if freePods == 0 {
+		return false
+	}
+	for _, resourceName := range schedulingResourceNames() {
+		requested := requests[resourceName]
+		if requested.Sign() == 0 {
+			continue
+		}
+		available := free[resourceName]
+		if available.Sign() <= 0 || available.Cmp(requested) < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func bestAvailableSchedulingCapacity(states []schedulingNodeState) string {
+	best := corev1.ResourceList{}
+	bestPods := int64(0)
+	for _, state := range states {
+		keepLargerSchedulingRequests(best, state.free)
+		if state.freePods > bestPods {
+			bestPods = state.freePods
+		}
+	}
+	return schedulingRequestsString(best, bestPods)
+}
+
+func schedulingRequestsString(requests corev1.ResourceList, pods int64) string {
+	parts := make([]string, 0, 4)
+	if cpu := requests[corev1.ResourceCPU]; cpu.Sign() != 0 {
+		parts = append(parts, "cpu="+cpu.String())
+	}
+	if memory := requests[corev1.ResourceMemory]; memory.Sign() != 0 {
+		parts = append(parts, "memory="+memory.String())
+	}
+	if ephemeral := requests[corev1.ResourceEphemeralStorage]; ephemeral.Sign() != 0 {
+		parts = append(parts, "ephemeral-storage="+ephemeral.String())
+	}
+	if pods >= 0 {
+		parts = append(parts, fmt.Sprintf("pods=%d", pods))
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, ", ")
+}
+
+func schedulingResourceNames() []corev1.ResourceName {
+	return []corev1.ResourceName{
+		corev1.ResourceCPU,
+		corev1.ResourceMemory,
+		corev1.ResourceEphemeralStorage,
+	}
+}
+
+func copyResourceListForScheduling(in corev1.ResourceList) corev1.ResourceList {
+	out := corev1.ResourceList{}
+	for _, resourceName := range schedulingResourceNames() {
+		if quantity := in[resourceName]; quantity.Sign() != 0 {
+			out[resourceName] = quantity.DeepCopy()
+		}
+	}
+	return out
+}
+
+func allocatablePods(node *corev1.Node) int64 {
+	if quantity := node.Status.Allocatable[corev1.ResourcePods]; quantity.Sign() > 0 {
+		return quantity.Value()
+	}
+	return math.MaxInt32
+}
+
+func podTerminated(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
+}
+
+func stringInSlice(value string, values []string) bool {
+	for _, candidate := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *schedulingBlockerSet) addPlacementDiagnostic(summary string) {
+	b.all = append(b.all, summary)
+	b.placement = append(b.placement, summary)
+}
+
+func (b *schedulingBlockerSet) addTaintDiagnostic(summary string) {
+	b.all = append(b.all, summary)
+	b.taints = append(b.taints, summary)
+}
+
+func (b *schedulingBlockerSet) addCapacityDiagnostic(summary string) {
+	b.all = append(b.all, summary)
+	b.capacity = append(b.capacity, summary)
+}

--- a/xtrinode/controllers/xtrinode_controller.go
+++ b/xtrinode/controllers/xtrinode_controller.go
@@ -59,12 +59,14 @@ type XTrinodeReconciler struct {
 // +kubebuilder:rbac:groups=analytics.xtrinode.io,resources=xtrinodes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=analytics.xtrinode.io,resources=xtrinodes/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;create;update;patch
+// +kubebuilder:rbac:groups="",resources=pods;nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=resourcequotas;limitranges,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments/scale,verbs=get;update;patch
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses;networkpolicies,verbs=get;list;watch;create;update;patch;delete
@@ -72,6 +74,8 @@ type XTrinodeReconciler struct {
 // +kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=keda.sh,resources=triggerauthentications,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments;machinepools,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machinesets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmachines;azuremachines;gcpmachines,verbs=get;list;watch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 func (r *XTrinodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -151,6 +155,15 @@ func (r *XTrinodeReconciler) reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
+	result, nodePoolRemovalErr := r.reconcileRemovedNodePool(ctx, &xtrinode)
+	if nodePoolRemovalErr != nil || result.RequeueAfter > 0 {
+		if nodePoolRemovalErr != nil {
+			metrics.ReconcileTotal.WithLabelValues(xtrinode.Namespace, xtrinode.Name, "error").Inc()
+			metrics.ReconcileErrors.WithLabelValues(xtrinode.Namespace, xtrinode.Name, "nodepool_removal_error").Inc()
+		}
+		return result, nodePoolRemovalErr
+	}
+
 	// Handle suspend/resume logic
 	if xtrinode.Spec.Suspended {
 		// XTrinode is suspended - disable KEDA first, then scale deployments
@@ -184,15 +197,15 @@ func (r *XTrinodeReconciler) reconcile(ctx context.Context, req ctrl.Request) (c
 	// Execute reconciliation pipeline
 	// KEDA remains fixed-replica unless the XTrinode has an explicit scaler config.
 	pipeline := NewReconciliationPipeline(r, &xtrinode)
-	result, err := pipeline.Execute(ctx, &xtrinode, log)
-	if err != nil {
-		r.EventRecorder.Warningf(&xtrinode, events.ReasonReconcileError, "Reconciliation failed: %v", err)
+	pipelineResult, pipelineErr := pipeline.Execute(ctx, &xtrinode, log)
+	if pipelineErr != nil {
+		r.EventRecorder.Warningf(&xtrinode, events.ReasonReconcileError, "Reconciliation failed: %v", pipelineErr)
 		metrics.ReconcileTotal.WithLabelValues(xtrinode.Namespace, xtrinode.Name, "error").Inc()
 		metrics.ReconcileErrors.WithLabelValues(xtrinode.Namespace, xtrinode.Name, "pipeline_error").Inc()
-		return result, err
+		return pipelineResult, pipelineErr
 	}
-	if result.RequeueAfter > 0 {
-		return result, nil
+	if pipelineResult.RequeueAfter > 0 {
+		return pipelineResult, nil
 	}
 
 	if err := r.reconcileReadyGatewayRoute(ctx, &xtrinode); err != nil {

--- a/xtrinode/controllers/xtrinode_controller_test.go
+++ b/xtrinode/controllers/xtrinode_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -27,11 +28,13 @@ import (
 )
 
 type recordingNodePoolAdapter struct {
-	ensurePhases []string
-	deleteCalls  int
-	retainCalls  int
-	scaleCalls   int
-	scaleValues  []int32
+	ensurePhases      []string
+	deleteCalls       int
+	retainCalls       int
+	retainErr         error
+	retainedNodePools []analyticsv1.NodePoolSpec
+	scaleCalls        int
+	scaleValues       []int32
 }
 
 func (r *recordingNodePoolAdapter) EnsureNodePool(_ context.Context, xtrinode *analyticsv1.XTrinode) error {
@@ -44,9 +47,12 @@ func (r *recordingNodePoolAdapter) DeleteNodePool(_ context.Context, _ *analytic
 	return nil
 }
 
-func (r *recordingNodePoolAdapter) RetainNodePool(_ context.Context, _ *analyticsv1.XTrinode) error {
+func (r *recordingNodePoolAdapter) RetainNodePool(_ context.Context, xtrinode *analyticsv1.XTrinode) error {
 	r.retainCalls++
-	return nil
+	if xtrinode.Spec.NodePool != nil {
+		r.retainedNodePools = append(r.retainedNodePools, *xtrinode.Spec.NodePool.DeepCopy())
+	}
+	return r.retainErr
 }
 
 func (r *recordingNodePoolAdapter) ScaleNodePoolMinNodes(_ context.Context, _ *analyticsv1.XTrinode, minNodes int32) error {
@@ -1832,6 +1838,148 @@ func TestCalculateRequeueInterval_WakeWindow(t *testing.T) {
 	interval := reconciler.calculateRequeueInterval(xtrinode)
 	assert.True(t, interval > 0, "Should have non-zero requeue interval for active wake")
 	assert.True(t, interval <= 2*time.Minute+time.Second, "Requeue interval should be ≤ remaining wake time")
+}
+
+func TestXTrinodeReconciler_reconcileRemovedNodePool_RetainsObservedNodePool(t *testing.T) {
+	scheme := newTestScheme()
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "runtime-a",
+			Namespace:  "team-a",
+			UID:        types.UID("runtime-a-uid"),
+			Generation: 3,
+		},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size: "s",
+		},
+		Status: analyticsv1.XTrinodeStatus{
+			ObservedRuntimeShape: &analyticsv1.ObservedRuntimeShapeStatus{
+				Version: analyticsv1.ObservedRuntimeShapeStatusVersion,
+				NodePool: analyticsv1.ObservedRuntimeNodePoolStatus{
+					ProvisioningRequested: true,
+					Provider:              "gcp",
+					ProviderMode:          "managed",
+					Name:                  "runtime-a-pool",
+					SchedulePods:          true,
+					DeletionPolicy:        analyticsv1.NodePoolDeletionPolicyDelete,
+				},
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(xtrinode).
+		WithStatusSubresource(&analyticsv1.XTrinode{}).
+		Build()
+	reconciler := newTestReconciler(cli, scheme)
+	nodePoolAdapter := &recordingNodePoolAdapter{}
+	reconciler.NodePoolAdapter = nodePoolAdapter
+
+	result, err := reconciler.reconcileRemovedNodePool(context.Background(), xtrinode)
+	assert.NoError(t, err)
+	assert.Equal(t, time.Duration(0), result.RequeueAfter)
+	assert.Equal(t, 1, nodePoolAdapter.retainCalls)
+	if assert.Len(t, nodePoolAdapter.retainedNodePools, 1) {
+		retained := nodePoolAdapter.retainedNodePools[0]
+		assert.Equal(t, "gcp", retained.Provider)
+		assert.Equal(t, "managed", retained.ProviderMode)
+		assert.Equal(t, "runtime-a-pool", retained.Name)
+		assert.True(t, retained.SchedulePods)
+		assert.Equal(t, analyticsv1.NodePoolDeletionPolicyRetain, retained.DeletionPolicy)
+	}
+
+	if assert.NotNil(t, xtrinode.Status.ObservedRuntimeShape) {
+		assert.False(t, xtrinode.Status.ObservedRuntimeShape.NodePool.ProvisioningRequested)
+		assert.Empty(t, xtrinode.Status.ObservedRuntimeShape.NodePool.Provider)
+	}
+	condition := status.GetCondition(xtrinode, status.ConditionTypeNodePoolReady)
+	if assert.NotNil(t, condition) {
+		assert.Equal(t, metav1.ConditionTrue, condition.Status)
+		assert.Equal(t, "NodePoolRetained", condition.Reason)
+	}
+
+	stored := &analyticsv1.XTrinode{}
+	assert.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: xtrinode.Name, Namespace: xtrinode.Namespace}, stored))
+	if assert.NotNil(t, stored.Status.ObservedRuntimeShape) {
+		assert.False(t, stored.Status.ObservedRuntimeShape.NodePool.ProvisioningRequested)
+	}
+}
+
+func TestXTrinodeReconciler_reconcileRemovedNodePool_SkipsWithoutObservedNodePool(t *testing.T) {
+	scheme := newTestScheme()
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "runtime-a",
+			Namespace: "team-a",
+		},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size: "s",
+		},
+		Status: analyticsv1.XTrinodeStatus{
+			ObservedRuntimeShape: &analyticsv1.ObservedRuntimeShapeStatus{
+				Version: analyticsv1.ObservedRuntimeShapeStatusVersion,
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(xtrinode).
+		WithStatusSubresource(&analyticsv1.XTrinode{}).
+		Build()
+	reconciler := newTestReconciler(cli, scheme)
+	nodePoolAdapter := &recordingNodePoolAdapter{}
+	reconciler.NodePoolAdapter = nodePoolAdapter
+
+	result, err := reconciler.reconcileRemovedNodePool(context.Background(), xtrinode)
+	assert.NoError(t, err)
+	assert.Equal(t, time.Duration(0), result.RequeueAfter)
+	assert.Equal(t, 0, nodePoolAdapter.retainCalls)
+}
+
+func TestXTrinodeReconciler_reconcileRemovedNodePool_RetainFailureKeepsObservedNodePool(t *testing.T) {
+	scheme := newTestScheme()
+	retainErr := errors.New("retain failed")
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "runtime-a",
+			Namespace: "team-a",
+		},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size: "s",
+		},
+		Status: analyticsv1.XTrinodeStatus{
+			ObservedRuntimeShape: &analyticsv1.ObservedRuntimeShapeStatus{
+				Version: analyticsv1.ObservedRuntimeShapeStatusVersion,
+				NodePool: analyticsv1.ObservedRuntimeNodePoolStatus{
+					ProvisioningRequested: true,
+					Provider:              "aws",
+					Name:                  "runtime-a-pool",
+				},
+			},
+		},
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(xtrinode).
+		WithStatusSubresource(&analyticsv1.XTrinode{}).
+		Build()
+	reconciler := newTestReconciler(cli, scheme)
+	nodePoolAdapter := &recordingNodePoolAdapter{retainErr: retainErr}
+	reconciler.NodePoolAdapter = nodePoolAdapter
+
+	result, err := reconciler.reconcileRemovedNodePool(context.Background(), xtrinode)
+	assert.ErrorIs(t, err, retainErr)
+	assert.Equal(t, config.NodePoolProvisioningErrorRequeueInterval, result.RequeueAfter)
+	assert.Equal(t, 1, nodePoolAdapter.retainCalls)
+	assert.True(t, xtrinode.Status.ObservedRuntimeShape.NodePool.ProvisioningRequested)
+	condition := status.GetCondition(xtrinode, status.ConditionTypeNodePoolReady)
+	if assert.NotNil(t, condition) {
+		assert.Equal(t, metav1.ConditionFalse, condition.Status)
+		assert.Equal(t, status.ConditionReasonNodePoolFailed, condition.Reason)
+	}
 }
 
 // --- Regression tests for regressions ---

--- a/xtrinode/controllers/xtrinode_finalizer.go
+++ b/xtrinode/controllers/xtrinode_finalizer.go
@@ -295,6 +295,22 @@ func (r *XTrinodeReconciler) cleanupResources(ctx context.Context, xtrinode *ana
 				r.EventRecorder.Normal(xtrinode, events.ReasonNodePoolDeleted, "Node pool deletion completed")
 			}
 		}
+	} else if retained, ok, err := xtrinodeWithRemovedObservedNodePool(xtrinode); ok {
+		if err != nil {
+			log.Error(err, "failed to reconstruct removed node pool from observed status during cleanup")
+			r.EventRecorder.Warningf(xtrinode, events.ReasonNodePoolRetainFailed, "Failed to retain removed node pool: %v", err)
+			criticalErr = errors.Join(criticalErr, fmt.Errorf("failed to retain removed node pool: %w", err))
+		} else {
+			nodePoolName := getNodePoolName(retained.Spec.NodePool, xtrinode.Name)
+			log.Info("Retaining removed node pool during XTrinode cleanup", "xtrinode", xtrinode.Name, "nodePool", nodePoolName)
+			if err := r.NodePoolAdapter.RetainNodePool(ctx, retained); err != nil {
+				log.Error(err, "failed to retain removed node pool")
+				r.EventRecorder.Warningf(xtrinode, events.ReasonNodePoolRetainFailed, "Failed to retain removed node pool: %v", err)
+				criticalErr = errors.Join(criticalErr, fmt.Errorf("failed to retain removed node pool: %w", err))
+			} else {
+				r.EventRecorder.Normal(xtrinode, events.ReasonNodePoolRetained, "Node pool retained because spec.nodePool was removed before deletion")
+			}
+		}
 	}
 
 	// Note: Catalog ConfigMaps are managed by XTrinodeCatalog controller via owner references

--- a/xtrinode/controllers/xtrinode_nodepool_reconcile.go
+++ b/xtrinode/controllers/xtrinode_nodepool_reconcile.go
@@ -87,6 +87,89 @@ func (r *XTrinodeReconciler) reconcileNodePoolBlocking(ctx context.Context, xtri
 	return ctrl.Result{}, nil
 }
 
+// reconcileRemovedNodePool retains the last observed provider node-pool
+// resources when spec.nodePool is removed from an existing runtime.
+func (r *XTrinodeReconciler) reconcileRemovedNodePool(ctx context.Context, xtrinode *analyticsv1.XTrinode) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	retained, ok, err := xtrinodeWithRemovedObservedNodePool(xtrinode)
+	if !ok {
+		return ctrl.Result{}, nil
+	}
+	if err != nil {
+		wrapped := fmt.Errorf("cannot retain removed node pool: %w", err)
+		log.Error(wrapped, "failed to reconstruct removed node pool from observed status")
+		status.SetCondition(xtrinode, status.ConditionTypeNodePoolReady, metav1.ConditionFalse, status.ConditionReasonNodePoolFailed, wrapped.Error())
+		r.EventRecorder.Warningf(xtrinode, events.ReasonNodePoolRetainFailed, "Failed to retain node pool after spec.nodePool removal: %v", err)
+		if updateErr := r.updateStatus(ctx, xtrinode, log); updateErr != nil {
+			log.Error(updateErr, "unable to update XTrinode status after node pool retention failure")
+		}
+		return ctrl.Result{RequeueAfter: config.NodePoolProvisioningErrorRequeueInterval}, wrapped
+	}
+
+	err = external.CallWithTimeout(ctx, config.NodePoolTimeout, func(ctx context.Context) error {
+		return r.NodePoolAdapter.RetainNodePool(ctx, retained)
+	})
+	if err != nil {
+		log.Error(err, "failed to retain removed node pool")
+		status.SetCondition(xtrinode, status.ConditionTypeNodePoolReady, metav1.ConditionFalse, status.ConditionReasonNodePoolFailed, fmt.Sprintf("Failed to retain removed node pool: %v", err))
+		r.EventRecorder.Warningf(xtrinode, events.ReasonNodePoolRetainFailed, "Failed to retain node pool after spec.nodePool removal: %v", err)
+		if updateErr := r.updateStatus(ctx, xtrinode, log); updateErr != nil {
+			log.Error(updateErr, "unable to update XTrinode status after node pool retention failure")
+		}
+		return ctrl.Result{RequeueAfter: getNodePoolErrorRequeueInterval(retained.Spec.NodePool)}, err
+	}
+
+	if err := setObservedRuntimeShapeStatus(xtrinode); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to refresh observed runtime shape after node pool retention: %w", err)
+	}
+	status.SetCondition(xtrinode, status.ConditionTypeNodePoolReady, metav1.ConditionTrue, events.ReasonNodePoolRetained, "Node pool retained because spec.nodePool was removed")
+	if err := r.updateStatus(ctx, xtrinode, log); err != nil {
+		log.Error(err, "unable to update XTrinode status after node pool retention")
+		return ctrl.Result{}, err
+	}
+
+	r.EventRecorder.Normalf(
+		xtrinode,
+		events.ReasonNodePoolRetained,
+		"Node pool %q retained because spec.nodePool was removed",
+		getNodePoolName(retained.Spec.NodePool, xtrinode.Name),
+	)
+	log.Info("Retained removed node pool", "nodePool", getNodePoolName(retained.Spec.NodePool, xtrinode.Name), "provider", retained.Spec.NodePool.Provider)
+	return ctrl.Result{}, nil
+}
+
+func xtrinodeWithRemovedObservedNodePool(xtrinode *analyticsv1.XTrinode) (*analyticsv1.XTrinode, bool, error) {
+	if xtrinode.Spec.NodePool != nil || xtrinode.Status.ObservedRuntimeShape == nil {
+		return nil, false, nil
+	}
+	observed := &xtrinode.Status.ObservedRuntimeShape.NodePool
+	if !observed.ProvisioningRequested {
+		return nil, false, nil
+	}
+
+	nodePool, err := nodePoolSpecFromObservedStatus(observed)
+	if err != nil {
+		return nil, true, err
+	}
+	retained := xtrinode.DeepCopy()
+	retained.Spec.NodePool = nodePool
+	return retained, true, nil
+}
+
+func nodePoolSpecFromObservedStatus(observed *analyticsv1.ObservedRuntimeNodePoolStatus) (*analyticsv1.NodePoolSpec, error) {
+	if observed.Provider == "" {
+		return nil, fmt.Errorf("last observed node-pool provider is empty")
+	}
+	return &analyticsv1.NodePoolSpec{
+		Provider:       observed.Provider,
+		ProviderMode:   observed.ProviderMode,
+		Name:           observed.Name,
+		SchedulePods:   observed.SchedulePods,
+		DeletionPolicy: analyticsv1.NodePoolDeletionPolicyRetain,
+	}, nil
+}
+
 // waitForNodePoolReady checks if node pool nodes are ready
 // Returns: (ready bool, result ctrl.Result, error)
 func (r *XTrinodeReconciler) waitForNodePoolReady(ctx context.Context, xtrinode *analyticsv1.XTrinode, log logr.Logger) (ready bool, result ctrl.Result, err error) {
@@ -113,6 +196,22 @@ func (r *XTrinodeReconciler) waitForNodePoolReady(ctx context.Context, xtrinode 
 			return false, ctrl.Result{RequeueAfter: requeueAfter}, nil
 		}
 		return false, ctrl.Result{}, err
+	}
+
+	diagnostic, diagnosticErr := r.nodePoolProvisioningFailureDiagnostic(ctx, xtrinode, res)
+	if diagnosticErr != nil {
+		log.Error(diagnosticErr, "failed to inspect node pool provisioning diagnostics")
+	}
+	if diagnostic != nil {
+		message := diagnostic.statusMessage()
+		log.Info("Node pool provisioning reported failure", "xtrinode", xtrinode.Name, "message", message)
+		status.SetCondition(xtrinode, status.ConditionTypeNodePoolReady, metav1.ConditionFalse, status.ConditionReasonNodePoolFailed, message)
+		r.EventRecorder.Warningf(xtrinode, events.ReasonNodePoolProvisionFailed, "Node pool provisioning reported failure: %s", message)
+		metrics.NodePoolProvisionFailed.WithLabelValues(xtrinode.Namespace, xtrinode.Name, nodePool.Provider).Inc()
+		if updateErr := r.updateStatus(ctx, xtrinode, log); updateErr != nil {
+			return false, ctrl.Result{}, updateErr
+		}
+		return false, ctrl.Result{RequeueAfter: getNodePoolErrorRequeueInterval(nodePool)}, nil
 	}
 
 	// Check status.readyReplicas


### PR DESCRIPTION
## Summary

- Add runtime scheduling diagnostics that classify pending Trino pods by placement, taints/tolerations, quota, node capacity, pod-slot pressure, and DaemonSet overhead.
- Add node-pool provisioning failure diagnostics that surface hard failures from CAPI resources, provider managed-pool resources, child Machines, and Machine infrastructure refs into `NodePoolReady`.
- Retain previously provisioned node-pool resources when `spec.nodePool` is removed, including the deletion/finalizer race path.
- Expand local Robot e2e coverage for placement, taint, and capacity scheduling blockers, and add an opt-in CAPG retain smoke target for real provider resources.
- Update RBAC and public architecture/Helm docs for the new diagnostics, node-pool retain behavior, webhook operations, and overlay policy guidance.

## Validation

- [x] Relevant local checks passed.
- [x] Skipped checks are explained below.

Checks run:

- `go test -count=1 ./...`
- `make lint-go`
- `make lint-helm`
- `make lint-markdown`
- `make gcp-refresh-edge-tests`
- Robot dry run: `tilt/e2e/robot/10_xtrinode_resource_contracts.robot`
- Live local k3d Robot resource contracts: `15 tests, 15 passed, 0 failed`
- `git diff --check`

Skipped:

- `make gcp-capg-nodepool-retain-smoke` was not run because it mutates live GCP/CAPG provider resources. The script and Make target are statically checked by `make gcp-refresh-edge-tests`.

## Risk

Medium. This changes operator reconciliation/status behavior and broadens operator RBAC reads for nodes, DaemonSets, CAPI Machines/MachineSets, and provider Machine resources. The new diagnostic paths are read-only except for status/events, and node-pool removal uses retain semantics by removing XTrinode owner references rather than deleting provider resources.

## Release Impact

- [x] This PR does not change release versioning, image publishing, or Helm chart packaging.
- [ ] This PR changes release behavior and the impact is described below.

## Notes

- The CAPG retain smoke is intentionally opt-in: `make gcp-capg-nodepool-retain-smoke`.
- Local e2e cannot honestly validate real provider node-pool lifecycle behavior without a live CAPI/CAPG environment, so provider-resource retain coverage is split between controller tests, static script checks, and the opt-in cloud smoke.
