### PR TITLE
Fix node-pool readiness status persistence

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -572,10 +572,14 @@ memory, ephemeral-storage, pod-slot pressure, and DaemonSet overhead. This
 diagnostic pass is bounded to status conditions; Kubernetes Events, pod status,
 and scheduler diagnostics remain the detailed source of truth. `NodePoolFitReady`
 records best-effort fit checks between resolved pod resources and known provider
-machine types. For configured node pools, `NodePoolReady` also correlates hard
-provisioning failures from Cluster API resources, provider managed-pool resources,
-child Machines, and Machine infrastructure refs when those resources expose
-failure fields or failed/error conditions.
+machine types. For configured node pools, `NodePoolReady=True` means the
+effective ready-replica requirement has passed, including operator node-pool
+defaults. `NodePoolReady=False` with `NodePoolProvisioning` means the node-pool
+resource exists or is being created but has not yet reported enough ready
+replicas. `NodePoolReady` also correlates hard provisioning failures from
+Cluster API resources, provider managed-pool resources, child Machines, and
+Machine infrastructure refs when those resources expose failure fields or
+failed/error conditions.
 
 ### Runtime Configuration Layers
 

--- a/tilt/e2e/robot/19_nodepool_contracts.robot
+++ b/tilt/e2e/robot/19_nodepool_contracts.robot
@@ -8,9 +8,11 @@ Test Teardown       Run Keyword If Test Failed    Dump Debug
 
 *** Variables ***
 ${NODEPOOL_DEFAULT_RUNTIME}       nodepool-default-readiness
+${NODEPOOL_SUSPENDED_RUNTIME}     nodepool-suspended-readiness
 ${FAKE_CAPI_CRDS}                 ${REPO_ROOT}/tilt/e2e/fixtures/fake-capi-nodepool-crds.yaml
 ${NODEPOOL_MACHINEPOOL_FILE}      /tmp/xtrinode-nodepool-default-machinepool.json
 ${NODEPOOL_INFRA_FILE}            /tmp/xtrinode-nodepool-default-infra.json
+${NODEPOOL_SUSPENDED_FILE}        /tmp/xtrinode-nodepool-suspended.json
 
 *** Test Cases ***
 Operator Node Pool Defaults Gate Runtime Until Required Replicas Are Ready
@@ -19,6 +21,7 @@ Operator Node Pool Defaults Gate Runtime Until Required Replicas Are Ready
     Apply NodePool Default Runtime
     Wait Until Keyword Succeeds    180s    ${POLL_INTERVAL}    MachinePool Should Have Operator Defaults
     Wait Until Keyword Succeeds    180s    ${POLL_INTERVAL}    GCPManagedMachinePool Should Have Operator Defaults
+    Wait Until Keyword Succeeds    180s    ${POLL_INTERVAL}    XTrinode NodePoolReady Should Be Provisioning    ${NODEPOOL_DEFAULT_RUNTIME}
 
     Sleep    25s
     Runtime Deployment Should Not Exist    ${NODEPOOL_DEFAULT_RUNTIME}    coordinator
@@ -26,6 +29,17 @@ Operator Node Pool Defaults Gate Runtime Until Required Replicas Are Ready
 
     Patch Fake MachinePool Status    2    2
     Wait Until Keyword Succeeds    180s    ${POLL_INTERVAL}    Runtime Deployment Should Exist    ${NODEPOOL_DEFAULT_RUNTIME}    coordinator
+
+Suspended Keep Warm Node Pool Does Not Report Ready Before Required Replicas
+    [Teardown]    Run Keywords    Run Keyword If Test Failed    Dump Debug    AND    Cleanup NodePool Contract Objects
+    Cleanup NodePool Contract Objects
+    Apply Suspended Keep Warm NodePool Runtime
+    Wait Until Keyword Succeeds    180s    ${POLL_INTERVAL}    MachinePool Should Have Operator Defaults For Runtime    ${NODEPOOL_SUSPENDED_RUNTIME}    ${NODEPOOL_MACHINEPOOL_FILE}
+    Wait Until Keyword Succeeds    180s    ${POLL_INTERVAL}    XTrinode NodePoolReady Should Be Provisioning    ${NODEPOOL_SUSPENDED_RUNTIME}
+
+    Patch Fake MachinePool Status    2    2    ${NODEPOOL_SUSPENDED_RUNTIME}
+    Command Should Succeed    kubectl    wait    xtrinode/${NODEPOOL_SUSPENDED_RUNTIME}    -n    ${NAMESPACE}    --for=condition=NodePoolReady=True    --timeout=180s
+    XTrinode NodePoolReady Reason Should Be    ${NODEPOOL_SUSPENDED_RUNTIME}    NodePoolReady
 
 *** Keywords ***
 Ensure NodePool Contract Prerequisites
@@ -43,10 +57,33 @@ Apply NodePool Default Runtime
     Create File    ${manifest}    ${json}
     Command Should Succeed    kubectl    apply    -f    ${manifest}
 
+Apply Suspended Keep Warm NodePool Runtime
+    ${manifest}=    Set Variable    /tmp/xtrinode-nodepool-suspended-readiness.json
+    ${json}=    Set Variable    {"apiVersion":"analytics.xtrinode.io/v1","kind":"XTrinode","metadata":{"name":"${NODEPOOL_SUSPENDED_RUNTIME}","namespace":"${NAMESPACE}","labels":{"test.xtrinode.io/contract":"nodepool-suspended-readiness"}},"spec":{"size":"xs","suspended":true,"minWorkers":0,"maxWorkers":0,"autoSuspendAfter":"30m","keda":{"enabled":false},"operatorNodePoolDefaults":{"defaultMinNodes":2,"defaultMaxNodes":4,"defaultOSDiskGB":64},"nodePool":{"provider":"gcp","providerMode":"managed","clusterName":"fake-cluster","kubernetesVersion":"v1.29.0","scaleDownOnSuspend":false,"gcp":{"machineType":"e2-standard-4"}},"routing":{"header":"X-Trino-XTrinode=${NAMESPACE}/${NODEPOOL_SUSPENDED_RUNTIME}","routingGroup":"${NODEPOOL_SUSPENDED_RUNTIME}"},"valuesOverlay":{"image":{"repository":"${TRINO_IMAGE_REPOSITORY}","tag":"${TRINO_IMAGE_TAG}","pullPolicy":"IfNotPresent"}}}}
+    Create File    ${manifest}    ${json}
+    Command Should Succeed    kubectl    apply    -f    ${manifest}
+
 MachinePool Should Have Operator Defaults
-    ${json}=    Kubectl Output    get    machinepools    ${NODEPOOL_DEFAULT_RUNTIME}-pool    -n    ${NAMESPACE}    -o    json
-    Create File    ${NODEPOOL_MACHINEPOOL_FILE}    ${json}
-    JQ Should Match    ${NODEPOOL_MACHINEPOOL_FILE}    .spec.replicas == 2 and .metadata.annotations["cluster-autoscaler/node-group-min-size"] == "2" and .metadata.annotations["cluster-autoscaler/node-group-max-size"] == "4"
+    MachinePool Should Have Operator Defaults For Runtime    ${NODEPOOL_DEFAULT_RUNTIME}    ${NODEPOOL_MACHINEPOOL_FILE}
+
+MachinePool Should Have Operator Defaults For Runtime
+    [Arguments]    ${runtime}    ${output_file}
+    ${json}=    Kubectl Output    get    machinepools    ${runtime}-pool    -n    ${NAMESPACE}    -o    json
+    Create File    ${output_file}    ${json}
+    JQ Should Match    ${output_file}    .spec.replicas == 2 and .metadata.annotations["cluster-autoscaler/node-group-min-size"] == "2" and .metadata.annotations["cluster-autoscaler/node-group-max-size"] == "4"
+
+XTrinode NodePoolReady Should Be Provisioning
+    [Arguments]    ${runtime}
+    ${json}=    Kubectl Output    get    xtrinode    ${runtime}    -n    ${NAMESPACE}    -o    json
+    Create File    ${NODEPOOL_SUSPENDED_FILE}    ${json}
+    JQ Should Match    ${NODEPOOL_SUSPENDED_FILE}    (.status.conditions // [] | map(select(.type == "NodePoolReady" and .status == "True")) | length) == 0
+    JQ Should Match    ${NODEPOOL_SUSPENDED_FILE}    any(.status.conditions[]?; .type == "NodePoolReady" and .status == "False" and .reason == "NodePoolProvisioning")
+
+XTrinode NodePoolReady Reason Should Be
+    [Arguments]    ${runtime}    ${reason}
+    ${json}=    Kubectl Output    get    xtrinode    ${runtime}    -n    ${NAMESPACE}    -o    json
+    Create File    ${NODEPOOL_SUSPENDED_FILE}    ${json}
+    JQ Should Match    ${NODEPOOL_SUSPENDED_FILE}    any(.status.conditions[]?; .type == "NodePoolReady" and .status == "True" and .reason == $reason)    --arg    reason    ${reason}
 
 GCPManagedMachinePool Should Have Operator Defaults
     ${json}=    Kubectl Output    get    gcpmanagedmachinepools    ${NODEPOOL_DEFAULT_RUNTIME}-pool    -n    ${NAMESPACE}    -o    json
@@ -54,9 +91,9 @@ GCPManagedMachinePool Should Have Operator Defaults
     JQ Should Match    ${NODEPOOL_INFRA_FILE}    .spec.scaling.minCount == 2 and .spec.scaling.maxCount == 4 and .spec.diskSizeGB == 64
 
 Patch Fake MachinePool Status
-    [Arguments]    ${ready_replicas}    ${replicas}
+    [Arguments]    ${ready_replicas}    ${replicas}    ${runtime}=${NODEPOOL_DEFAULT_RUNTIME}
     ${patch}=    Set Variable    {"status":{"readyReplicas":${ready_replicas},"replicas":${replicas}}}
-    Command Should Succeed    kubectl    patch    machinepools    ${NODEPOOL_DEFAULT_RUNTIME}-pool    -n    ${NAMESPACE}    --subresource=status    --type=merge    -p    ${patch}
+    Command Should Succeed    kubectl    patch    machinepools    ${runtime}-pool    -n    ${NAMESPACE}    --subresource=status    --type=merge    -p    ${patch}
 
 Runtime Deployment Should Not Exist
     [Arguments]    ${runtime}    ${component}
@@ -69,7 +106,11 @@ Runtime Deployment Should Exist
 
 Cleanup NodePool Contract Objects
     Run Command Allow Failure    kubectl    patch    xtrinode/${NODEPOOL_DEFAULT_RUNTIME}    -n    ${NAMESPACE}    --type=merge    -p    {"metadata":{"finalizers":[]}}
+    Run Command Allow Failure    kubectl    patch    xtrinode/${NODEPOOL_SUSPENDED_RUNTIME}    -n    ${NAMESPACE}    --type=merge    -p    {"metadata":{"finalizers":[]}}
     Run Command Allow Failure    kubectl    delete    xtrinode/${NODEPOOL_DEFAULT_RUNTIME}    -n    ${NAMESPACE}    --ignore-not-found=true    --wait=false
+    Run Command Allow Failure    kubectl    delete    xtrinode/${NODEPOOL_SUSPENDED_RUNTIME}    -n    ${NAMESPACE}    --ignore-not-found=true    --wait=false
     Run Command Allow Failure    kubectl    delete    deployment,service,configmap,poddisruptionbudget,serviceaccount,horizontalpodautoscaler,scaledobject,triggerauthentication    -n    ${NAMESPACE}    -l    app.kubernetes.io/instance=${NODEPOOL_DEFAULT_RUNTIME}    --ignore-not-found=true    --wait=false
     Run Command Allow Failure    kubectl    delete    machinepools    ${NODEPOOL_DEFAULT_RUNTIME}-pool    -n    ${NAMESPACE}    --ignore-not-found=true    --wait=false
+    Run Command Allow Failure    kubectl    delete    machinepools    ${NODEPOOL_SUSPENDED_RUNTIME}-pool    -n    ${NAMESPACE}    --ignore-not-found=true    --wait=false
     Run Command Allow Failure    kubectl    delete    gcpmanagedmachinepools    ${NODEPOOL_DEFAULT_RUNTIME}-pool    -n    ${NAMESPACE}    --ignore-not-found=true    --wait=false
+    Run Command Allow Failure    kubectl    delete    gcpmanagedmachinepools    ${NODEPOOL_SUSPENDED_RUNTIME}-pool    -n    ${NAMESPACE}    --ignore-not-found=true    --wait=false

--- a/xtrinode/controllers/xtrinode_controller_test.go
+++ b/xtrinode/controllers/xtrinode_controller_test.go
@@ -24,6 +24,7 @@ import (
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	analyticsv1 "github.com/xtrinode/xtrinode/api/v1"
 	"github.com/xtrinode/xtrinode/internal/config"
+	"github.com/xtrinode/xtrinode/internal/events"
 	"github.com/xtrinode/xtrinode/internal/status"
 )
 
@@ -693,6 +694,74 @@ func TestXTrinodeReconciler_reconcileSuspend_ProvisionsNodePoolWithoutTrinoRunti
 	assert.True(t, k8serrors.IsNotFound(err), "suspended node-pool provisioning must not create Trino coordinator deployments")
 }
 
+func TestXTrinodeReconciler_Reconcile_PersistsActiveNodePoolProvisioningStatus(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = analyticsv1.AddToScheme(scheme)
+	_ = kedav1alpha1.AddToScheme(scheme)
+
+	minNodes := int32(2)
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "active-capg",
+			Namespace:  "team-a",
+			Generation: 7,
+			Finalizers: []string{FinalizerName},
+		},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size: "xs",
+			NodePool: &analyticsv1.NodePoolSpec{
+				Name:              "np-active-capg",
+				Provider:          "gcp",
+				ProviderMode:      "managed",
+				ClusterName:       "capg-workload",
+				KubernetesVersion: "v1.35.3",
+				MinNodes:          &minNodes,
+				GCP: &analyticsv1.GCPNodePoolSpec{
+					MachineType: "e2-medium",
+				},
+			},
+		},
+		Status: analyticsv1.XTrinodeStatus{
+			Phase:              string(status.PhaseReady),
+			ObservedGeneration: 6,
+		},
+	}
+
+	machinePool := &unstructured.Unstructured{}
+	machinePool.SetGroupVersionKind(getMachineResourceGVK(true))
+	machinePool.SetName("np-active-capg")
+	machinePool.SetNamespace("team-a")
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(xtrinode).
+		WithObjects(xtrinode, machinePool).
+		Build()
+	reconciler := newTestReconciler(cli, scheme)
+	reconciler.NamespaceGuardrailMode = NamespaceGuardrailModeDisabled
+	reconciler.NodePoolAdapter = &recordingNodePoolAdapter{}
+
+	result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "active-capg", Namespace: "team-a"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, config.NodePoolStatusNotAvailableRequeueInterval, result.RequeueAfter)
+
+	stored := &analyticsv1.XTrinode{}
+	err = cli.Get(context.Background(), types.NamespacedName{Name: "active-capg", Namespace: "team-a"}, stored)
+	assert.NoError(t, err)
+	assert.Equal(t, "Reconciling", stored.Status.Phase)
+
+	condition := status.GetCondition(stored, status.ConditionTypeNodePoolReady)
+	if assert.NotNil(t, condition) {
+		assert.Equal(t, metav1.ConditionFalse, condition.Status)
+		assert.Equal(t, events.ReasonNodePoolProvisioning, condition.Reason)
+		assert.Contains(t, condition.Message, "waiting for 2 ready replicas")
+		assert.Equal(t, int64(7), condition.ObservedGeneration)
+	}
+}
+
 func TestXTrinodeReconciler_reconcileSuspend_ProvisionsNodePoolAfterFreshSuspend(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
@@ -778,7 +847,7 @@ func TestXTrinodeReconciler_reconcileSuspendedNodePool_SkipsCurrentReadyNodePool
 			Phase: string(status.PhaseSuspended),
 		},
 	}
-	status.SetCondition(xtrinode, status.ConditionTypeNodePoolReady, metav1.ConditionTrue, "NodePoolProvisioned", "node pool already current")
+	status.SetCondition(xtrinode, status.ConditionTypeNodePoolReady, metav1.ConditionTrue, events.ReasonNodePoolReady, "node pool already current")
 
 	machinePool := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -806,6 +875,83 @@ func TestXTrinodeReconciler_reconcileSuspendedNodePool_SkipsCurrentReadyNodePool
 	assert.NoError(t, err)
 	assert.Equal(t, time.Duration(0), result.RequeueAfter)
 	assert.Empty(t, nodePoolAdapter.ensurePhases)
+}
+
+func TestXTrinodeReconciler_reconcileSuspendedNodePool_DoesNotPersistReadyBeforeRequiredReplicas(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = analyticsv1.AddToScheme(scheme)
+
+	keepNodePoolWarm := false
+	xtrinode := &analyticsv1.XTrinode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "waiting-suspended-capg",
+			Namespace:  "team-a",
+			Generation: 9,
+		},
+		Spec: analyticsv1.XTrinodeSpec{
+			Size:      "xs",
+			Suspended: true,
+			OperatorNodePoolDefaults: &analyticsv1.OperatorNodePoolDefaultsSpec{
+				DefaultMinNodes: int32Ptr(2),
+			},
+			NodePool: &analyticsv1.NodePoolSpec{
+				Name:               "np-waiting-suspended",
+				Provider:           "gcp",
+				ProviderMode:       "managed",
+				ClusterName:        "capg-workload",
+				KubernetesVersion:  "v1.35.3",
+				ScaleDownOnSuspend: &keepNodePoolWarm,
+				GCP: &analyticsv1.GCPNodePoolSpec{
+					MachineType: "e2-medium",
+				},
+			},
+		},
+		Status: analyticsv1.XTrinodeStatus{
+			Phase: string(status.PhaseSuspended),
+		},
+	}
+
+	machinePool := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{},
+				},
+			},
+		},
+	}
+	machinePool.SetGroupVersionKind(getMachineResourceGVK(true))
+	machinePool.SetName("np-waiting-suspended")
+	machinePool.SetNamespace("team-a")
+
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(xtrinode).
+		WithObjects(xtrinode, machinePool).
+		Build()
+	reconciler := newTestReconciler(cli, scheme)
+	nodePoolAdapter := &recordingNodePoolAdapter{}
+	reconciler.NodePoolAdapter = nodePoolAdapter
+
+	result, err := reconciler.reconcileSuspendedNodePool(context.Background(), xtrinode, newTestLogger())
+	assert.NoError(t, err)
+	assert.Equal(t, config.NodePoolStatusNotAvailableRequeueInterval, result.RequeueAfter)
+	assert.Equal(t, []string{string(status.PhaseSuspended)}, nodePoolAdapter.ensurePhases)
+
+	stored := &analyticsv1.XTrinode{}
+	assert.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: xtrinode.Name, Namespace: xtrinode.Namespace}, stored))
+	condition := status.GetCondition(stored, status.ConditionTypeNodePoolReady)
+	if assert.NotNil(t, condition) {
+		assert.Equal(t, metav1.ConditionFalse, condition.Status)
+		assert.Equal(t, events.ReasonNodePoolProvisioning, condition.Reason)
+		assert.Equal(t, int64(9), condition.ObservedGeneration)
+	}
+
+	result, err = reconciler.reconcileSuspendedNodePool(context.Background(), stored, newTestLogger())
+	assert.NoError(t, err)
+	assert.Equal(t, config.NodePoolStatusNotAvailableRequeueInterval, result.RequeueAfter)
+	assert.Equal(t, []string{string(status.PhaseSuspended), string(status.PhaseSuspended)}, nodePoolAdapter.ensurePhases)
 }
 
 func TestXTrinodeReconciler_reconcileSuspendedNodePool_RepairsBareGKEVersion(t *testing.T) {
@@ -839,7 +985,7 @@ func TestXTrinodeReconciler_reconcileSuspendedNodePool_RepairsBareGKEVersion(t *
 			Phase: string(status.PhaseSuspended),
 		},
 	}
-	status.SetCondition(xtrinode, status.ConditionTypeNodePoolReady, metav1.ConditionTrue, "NodePoolProvisioned", "node pool already current")
+	status.SetCondition(xtrinode, status.ConditionTypeNodePoolReady, metav1.ConditionTrue, events.ReasonNodePoolReady, "node pool already current")
 
 	machinePool := &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/xtrinode/controllers/xtrinode_nodepool_reconcile.go
+++ b/xtrinode/controllers/xtrinode_nodepool_reconcile.go
@@ -60,7 +60,6 @@ func (r *XTrinodeReconciler) reconcileNodePoolBlocking(ctx context.Context, xtri
 		requeueAfter := getNodePoolErrorRequeueInterval(xtrinode.Spec.NodePool)
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
-	status.SetCondition(xtrinode, status.ConditionTypeNodePoolReady, metav1.ConditionTrue, "NodePoolProvisioned", nodePoolProvisionedMessage(xtrinode))
 	setNodePoolFitCondition(xtrinode)
 	if isFirstProvision {
 		metrics.NodePoolProvisioned.WithLabelValues(xtrinode.Namespace, xtrinode.Name, nodePool.Provider).Inc()
@@ -84,6 +83,7 @@ func (r *XTrinodeReconciler) reconcileNodePoolBlocking(ctx context.Context, xtri
 	// Node-pool readiness requirement is satisfied; for scale-to-zero pools this
 	// can mean the node-pool resource exists before any node has been created.
 	log.Info("Node pool readiness requirement is satisfied", "xtrinode", xtrinode.Name)
+	status.SetCondition(xtrinode, status.ConditionTypeNodePoolReady, metav1.ConditionTrue, events.ReasonNodePoolReady, nodePoolProvisionedMessage(xtrinode))
 	r.EventRecorder.Normalf(xtrinode, events.ReasonNodePoolReady, "Node pool readiness requirement is satisfied for provider %s", nodePool.Provider)
 	return ctrl.Result{}, nil
 }
@@ -194,6 +194,7 @@ func (r *XTrinodeReconciler) waitForNodePoolReady(ctx context.Context, xtrinode 
 			// Resource not found yet, requeue
 			requeueAfter := getNodePoolResourceNotFoundRequeueInterval(nodePool)
 			log.Info("Node pool resource not found yet, requeuing", "name", nodePoolName, "requeueAfter", requeueAfter)
+			setNodePoolProvisioningCondition(xtrinode, fmt.Sprintf("Node pool resource %q is not available yet", nodePoolName))
 			return false, ctrl.Result{RequeueAfter: requeueAfter}, nil
 		}
 		return false, ctrl.Result{}, err
@@ -231,6 +232,7 @@ func (r *XTrinodeReconciler) waitForNodePoolReady(ctx context.Context, xtrinode 
 	if !found {
 		requeueAfter := getNodePoolStatusNotAvailableRequeueInterval(nodePool)
 		log.Info("Node pool status not available yet, requeuing", "name", nodePoolName, "requeueAfter", requeueAfter)
+		setNodePoolProvisioningCondition(xtrinode, fmt.Sprintf("Node pool status is not available yet; waiting for %d ready replicas", requiredReplicas))
 		return false, ctrl.Result{RequeueAfter: requeueAfter}, nil
 	}
 
@@ -250,6 +252,7 @@ func (r *XTrinodeReconciler) waitForNodePoolReady(ctx context.Context, xtrinode 
 		"readyReplicas", readyReplicas,
 		"requiredReplicas", requiredReplicas,
 		"replicas", replicas)
+	setNodePoolProvisioningCondition(xtrinode, fmt.Sprintf("Node pool has %d ready replicas; waiting for %d required ready replicas", readyReplicas, requiredReplicas))
 
 	// Requeue with configurable intervals based on readiness
 	var requeueAfter time.Duration
@@ -260,4 +263,8 @@ func (r *XTrinodeReconciler) waitForNodePoolReady(ctx context.Context, xtrinode 
 	}
 
 	return false, ctrl.Result{RequeueAfter: requeueAfter}, nil
+}
+
+func setNodePoolProvisioningCondition(xtrinode *analyticsv1.XTrinode, message string) {
+	status.SetCondition(xtrinode, status.ConditionTypeNodePoolReady, metav1.ConditionFalse, events.ReasonNodePoolProvisioning, message)
 }

--- a/xtrinode/controllers/xtrinode_reconciliation_steps.go
+++ b/xtrinode/controllers/xtrinode_reconciliation_steps.go
@@ -256,6 +256,10 @@ func (s *reconcileNodePoolStep) Execute(ctx context.Context, xtrinode *analytics
 	if result.RequeueAfter > 0 {
 		state.Log.Info("Node pool not ready yet, requeuing", "xtrinode", xtrinode.Name, "requeueAfter", result.RequeueAfter)
 		s.reconciler.EventRecorder.Normalf(xtrinode, events.ReasonNodePoolProvisioning, "Node pool provisioning in progress, requeue in %v", result.RequeueAfter)
+		if updateErr := s.reconciler.updateStatus(ctx, xtrinode, state.Log); updateErr != nil {
+			state.Log.Error(updateErr, "unable to update active node pool provisioning status")
+			return ctrl.Result{}, false, updateErr
+		}
 		return result, false, nil
 	}
 

--- a/xtrinode/controllers/xtrinode_suspend.go
+++ b/xtrinode/controllers/xtrinode_suspend.go
@@ -191,6 +191,7 @@ func suspendedNodePoolProvisioningCurrent(xtrinode *analyticsv1.XTrinode) bool {
 	condition := status.GetCondition(xtrinode, status.ConditionTypeNodePoolReady)
 	return condition != nil &&
 		condition.Status == metav1.ConditionTrue &&
+		condition.Reason == events.ReasonNodePoolReady &&
 		condition.ObservedGeneration == xtrinode.Generation
 }
 


### PR DESCRIPTION
## Summary

- Fix node-pool readiness status persistence for active runtimes. The active reconciliation pipeline now writes `NodePoolReady=False` with reason `NodePoolProvisioning` before returning a node-pool readiness requeue, matching the documented condition contract and the suspended keep-warm path.
- Tighten node-pool readiness semantics so `NodePoolReady=True` is only emitted after the effective ready-replica requirement is satisfied. Legacy or premature `NodePoolProvisioned` conditions no longer let suspended keep-warm node-pool reconciliation skip readiness checks.
- Add regression coverage for both active and suspended node-pool readiness flows, including operator node-pool defaults where `defaultMinNodes` supplies the effective minimum.
- Update architecture documentation to describe the `NodePoolReady` contract for provisioning, failure, and ready states.

Root cause: `waitForNodePoolReady()` updated the in-memory `XTrinode` status when a node pool was missing status or ready replicas, but the active-runtime pipeline returned early on `RequeueAfter` before any status update persisted that condition. Suspended keep-warm reconciliation had its own explicit status write, so the behavior differed by lifecycle path.

## Validation

- [x] Relevant local checks passed.
- [x] Skipped checks are explained below.

Checks run:

- `go test ./controllers -run 'TestXTrinodeReconciler_Reconcile_PersistsActiveNodePoolProvisioningStatus|TestXTrinodeReconciler_reconcileSuspendedNodePool|TestWaitForNodePoolReady'`
- `tilt/e2e/.venv/bin/robot --dryrun --outputdir /tmp/xtrinode-robot-dryrun tilt/e2e/robot/19_nodepool_contracts.robot`
- `go test ./...`
- `make test` (`70.8%` coverage, threshold `70%`)
- `make ci-lint`
- `make test-e2e-local-contracts` (`57 tests, 57 passed`)
- Previously verified from a clean local k3d cluster with `make test-e2e-local` (`95 tests, 94 passed, 0 failed, 1 skipped`)

Skipped checks:

- Live GKE smoke remains opt-in and was skipped by the full local Robot suite unless `GKE_E2E_ENABLED=true` is set against a selected GKE context.

## Risk

Low. The behavioral change is limited to persisting an already-computed node-pool provisioning condition before an active-runtime requeue. It improves observability and contract consistency without changing the node-pool readiness threshold or resource creation order.

Compatibility notes:

- Active runtimes with node pools may now expose `NodePoolReady=False` / `NodePoolProvisioning` earlier and more consistently while waiting for MachinePool status or ready replicas.
- `NodePoolReady=True` now represents the effective ready-replica requirement being satisfied, including operator node-pool defaults.

## Release Impact

- [x] This PR does not change release versioning, image publishing, or Helm chart packaging.
- [ ] This PR changes release behavior and the impact is described below.

## Notes

- No observability Helm chart value changes are included. `forceConflicts` was evaluated during local debugging and intentionally removed.
- The local e2e node-pool contract now covers the active-runtime provisioning status in addition to the suspended keep-warm readiness path.
