### PR TITLE
Decouple release versioning and image publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,14 @@ jobs:
       pr_author: ${{ steps.prepare.outputs.pr_author }}
       pr_head_owner: ${{ steps.prepare.outputs.pr_head_owner }}
       pr_number: ${{ steps.prepare.outputs.pr_number }}
-      image_version: ${{ steps.prepare.outputs.image_version }}
+      api_server_image_version: ${{ steps.prepare.outputs.api_server_image_version }}
+      api_server_chart_version: ${{ steps.prepare.outputs.api_server_chart_version }}
+      app_version: ${{ steps.prepare.outputs.app_version }}
+      gateway_chart_version: ${{ steps.prepare.outputs.gateway_chart_version }}
+      gateway_image_version: ${{ steps.prepare.outputs.gateway_image_version }}
+      image_matrix: ${{ steps.prepare.outputs.image_matrix }}
+      operator_chart_version: ${{ steps.prepare.outputs.operator_chart_version }}
+      operator_image_version: ${{ steps.prepare.outputs.operator_image_version }}
       should_release: ${{ steps.prepare.outputs.should_release }}
       should_publish_images: ${{ steps.prepare.outputs.should_publish_images }}
       tag: ${{ steps.prepare.outputs.tag }}
@@ -73,40 +80,23 @@ jobs:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
         run: make ci-create-release-tag
 
-  image-matrix:
-    name: Image Matrix
-    runs-on: ubuntu-latest
-    needs: [prepare-release]
-    if: needs.prepare-release.outputs.should_release == 'true' && needs.prepare-release.outputs.should_publish_images == 'true'
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-    steps:
-      - name: Checkout release commit
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ needs.prepare-release.outputs.target_sha }}
-
-      - name: Generate image matrix
-        id: matrix
-        run: make ci-image-matrix-output
-
   release-images:
     name: Release Image (${{ matrix.component }})
     runs-on: ubuntu-latest
-    needs: [prepare-release, create-tag, image-matrix]
-    if: needs.prepare-release.outputs.should_release == 'true' && needs.prepare-release.outputs.should_publish_images == 'true'
+    needs: [prepare-release, ci, create-tag]
+    if: ${{ always() && needs.prepare-release.outputs.should_publish_images == 'true' && needs.ci.result == 'success' && (needs.prepare-release.outputs.should_release != 'true' || needs.create-tag.result == 'success') }}
     permissions:
       contents: read
       packages: write
     strategy:
       fail-fast: true
-      matrix: ${{ fromJSON(needs.image-matrix.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.prepare-release.outputs.image_matrix) }}
     steps:
-      - name: Checkout release tag
+      - name: Checkout release commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.prepare-release.outputs.tag }}
+          ref: ${{ needs.prepare-release.outputs.target_sha }}
 
       - name: Read CI tool versions
         id: tool-versions
@@ -131,16 +121,26 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
           tags: |
-            type=semver,pattern={{version}},value=v${{ needs.prepare-release.outputs.image_version }}
-            type=semver,pattern={{major}}.{{minor}},value=v${{ needs.prepare-release.outputs.image_version }}
-            type=semver,pattern={{major}},value=v${{ needs.prepare-release.outputs.image_version }}
-            type=raw,value=latest,enable=${{ !contains(needs.prepare-release.outputs.image_version, '-') }}
+            type=semver,pattern={{version}},value=v${{ matrix.version }}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ matrix.version }},enable=${{ !contains(matrix.version, '-') }}
+            type=semver,pattern={{major}},value=v${{ matrix.version }},enable=${{ !contains(matrix.version, '-') }}
+            type=raw,value=latest,enable=${{ !contains(matrix.version, '-') }}
+
+      - name: Check exact image tag immutability
+        id: image-preflight
+        env:
+          RELEASE_IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          RELEASE_IMAGE_VERSION: ${{ matrix.version }}
+          TARGET_SHA: ${{ needs.prepare-release.outputs.target_sha }}
+        run: make ci-release-image-preflight
 
       - name: Compute build timestamp
         id: build-date
+        if: steps.image-preflight.outputs.should_push == 'true'
         run: make ci-build-date-output
 
       - name: Build image for scan
+        if: steps.image-preflight.outputs.should_push == 'true'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: xtrinode
@@ -149,21 +149,27 @@ jobs:
           load: true
           push: false
           tags: local/${{ matrix.image }}:scan-${{ needs.prepare-release.outputs.target_sha }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.version=${{ matrix.version }}
+            org.opencontainers.image.revision=${{ needs.prepare-release.outputs.target_sha }}
+            org.opencontainers.image.created=${{ steps.build-date.outputs.value }}
           cache-from: type=gha
           build-args: |
             GO_VERSION=${{ steps.tool-versions.outputs.go }}
             ALPINE_VERSION=${{ steps.tool-versions.outputs.alpine }}
             APP_PACKAGE=${{ matrix.package }}
             APP_PORT=${{ matrix.port }}
-            VERSION=${{ needs.prepare-release.outputs.image_version }}
+            VERSION=${{ matrix.version }}
             GIT_COMMIT=${{ needs.prepare-release.outputs.target_sha }}
             BUILD_DATE=${{ steps.build-date.outputs.value }}
 
       - name: Scan image
+        if: steps.image-preflight.outputs.should_push == 'true'
         run: make ci-scan-image IMAGE=local/${{ matrix.image }}:scan-${{ needs.prepare-release.outputs.target_sha }}
 
       - name: Build and push image
+        if: steps.image-preflight.outputs.should_push == 'true'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: xtrinode
@@ -171,7 +177,11 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.version=${{ matrix.version }}
+            org.opencontainers.image.revision=${{ needs.prepare-release.outputs.target_sha }}
+            org.opencontainers.image.created=${{ steps.build-date.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -179,7 +189,7 @@ jobs:
             ALPINE_VERSION=${{ steps.tool-versions.outputs.alpine }}
             APP_PACKAGE=${{ matrix.package }}
             APP_PORT=${{ matrix.port }}
-            VERSION=${{ needs.prepare-release.outputs.image_version }}
+            VERSION=${{ matrix.version }}
             GIT_COMMIT=${{ needs.prepare-release.outputs.target_sha }}
             BUILD_DATE=${{ steps.build-date.outputs.value }}
 
@@ -230,21 +240,23 @@ jobs:
 
             ${{ steps.release-notes.outputs.notes }}
 
-            ## Docker Images
+            ## Chart Default Image Tags
+
+            Component images are published independently when their chart `appVersion` changes.
 
             ```
-            ghcr.io/xtrinode/xtrinode-operator:${{ needs.prepare-release.outputs.image_version }}
-            ghcr.io/xtrinode/xtrinode-gateway:${{ needs.prepare-release.outputs.image_version }}
-            ghcr.io/xtrinode/xtrinode-api-server:${{ needs.prepare-release.outputs.image_version }}
+            ghcr.io/xtrinode/xtrinode-operator:${{ needs.prepare-release.outputs.operator_image_version }}
+            ghcr.io/xtrinode/xtrinode-gateway:${{ needs.prepare-release.outputs.gateway_image_version }}
+            ghcr.io/xtrinode/xtrinode-api-server:${{ needs.prepare-release.outputs.api_server_image_version }}
             ```
 
             ## Helm Charts
 
             ```bash
             helm install xtrinode ./xtrinode-${{ needs.prepare-release.outputs.version }}.tgz
-            helm install xtrinode-operator ./xtrinode-operator-${{ needs.prepare-release.outputs.version }}.tgz
-            helm install xtrinode-api-server ./xtrinode-api-server-${{ needs.prepare-release.outputs.version }}.tgz
-            helm install xtrinode-gateway ./xtrinode-gateway-${{ needs.prepare-release.outputs.version }}.tgz
+            helm install xtrinode-operator ./xtrinode-operator-${{ needs.prepare-release.outputs.operator_chart_version }}.tgz
+            helm install xtrinode-api-server ./xtrinode-api-server-${{ needs.prepare-release.outputs.api_server_chart_version }}.tgz
+            helm install xtrinode-gateway ./xtrinode-gateway-${{ needs.prepare-release.outputs.gateway_chart_version }}.tgz
             ```
           draft: false
           prerelease: ${{ contains(needs.prepare-release.outputs.version, '-') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+repos:
+  - repo: local
+    hooks:
+      - id: git-diff-check
+        name: Check staged whitespace
+        entry: git diff --check --cached
+        language: system
+        pass_filenames: false
+        always_run: true
+      - id: shell-syntax
+        name: Check Bash script syntax
+        entry: make lint-shell
+        language: system
+        pass_filenames: false
+        types: [shell]
+      - id: yaml-syntax
+        name: Check YAML syntax
+        entry: make lint-yaml
+        language: system
+        pass_filenames: false
+        types: [yaml]
+      - id: markdown-lint
+        name: Lint Markdown
+        entry: make lint-markdown
+        language: system
+        pass_filenames: false
+        types: [markdown]
+      - id: release-version-metadata
+        name: Validate release version metadata
+        entry: bash -c 'source scripts/ci/release-lib.sh; validate_release_version_metadata'
+        language: system
+        pass_filenames: false
+        files: '^helm/(xtrinode|xtrinode-(operator|api-server|gateway))/(Chart\.yaml|Chart\.lock)$'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,7 @@ Useful first commands:
 make help
 make tool-versions
 nvm use && npm ci
+make pre-commit-install
 make helm-deps
 make build-all
 make lint-markdown
@@ -152,6 +153,7 @@ enough. For Go, Helm, Terraform, or deployment changes, run the relevant Make ta
 Common checks:
 
 ```bash
+make pre-commit-run
 make ci-lint
 make ci-test
 make ci-verify-manifests

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ MAKE_CMD ?= make
 GODOC ?= $(GO_TOOL_BIN)/godoc
 GODOC_VERSION ?= v0.1.0-deprecated
 OPEN ?= xdg-open
+PRE_COMMIT ?= pre-commit
 
 # Security tooling
 TRIVY ?= trivy
@@ -264,6 +265,7 @@ help: ## Display this help message
 	@echo "  TF_ENV               Terraform environment (default: dev)"
 	@echo "  TF_VAR_FILE          Terraform variables file (default: terraform.tfvars)"
 	@echo "  TERRAFORM_CLOUDS     Terraform clouds used by generic/CI checks (default: gcp)"
+	@echo "  PRE_COMMIT           pre-commit command (default: pre-commit)"
 	@echo ""
 	@echo "Tooling: make tool-versions and docs/TOOLING.md show required local versions."
 	@echo "Deployment: make deploy-gcp | make deploy-aws | make deploy-azure | make deploy"
@@ -417,6 +419,14 @@ lint-markdown: ## Run Markdown linter
 	@echo "Running Markdown lint..."
 	@$(NPM) run --silent lint:markdown
 	@echo "Markdown linting complete"
+
+.PHONY: pre-commit-install
+pre-commit-install: ## Install local pre-commit hooks
+	$(PRE_COMMIT) install
+
+.PHONY: pre-commit-run
+pre-commit-run: ## Run pre-commit hooks on all files
+	$(PRE_COMMIT) run --all-files
 
 .PHONY: lint-terraform
 lint-terraform: ## Run Terraform linter for configured clouds (tflint)

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,18 @@ GATEWAY_IMAGE_NAME ?= xtrinode-gateway
 API_SERVER_IMAGE_NAME ?= xtrinode-api-server
 GIT_TAG ?= $(shell git describe --tags --exact-match 2>/dev/null || true)
 VERSION ?= $(if $(GIT_TAG),$(patsubst v%,%,$(GIT_TAG)),dev)
-IMAGE_VERSION ?= $(shell awk '/^appVersion:/ {print $$2; exit}' helm/xtrinode/Chart.yaml 2>/dev/null | tr -d '"' || echo "$(VERSION)")
-IMAGE_TAG ?= $(if $(GIT_TAG),$(IMAGE_VERSION),$(VERSION))
-CLOUD_IMAGE_TAG ?= $(if $(filter dev,$(IMAGE_TAG)),$(IMAGE_VERSION),$(IMAGE_TAG))
-IMG ?= $(REGISTRY)/$(OPERATOR_IMAGE_NAME):$(IMAGE_TAG)
-GATEWAY_IMG ?= $(REGISTRY)/$(GATEWAY_IMAGE_NAME):$(IMAGE_TAG)
-API_SERVER_IMG ?= $(REGISTRY)/$(API_SERVER_IMAGE_NAME):$(IMAGE_TAG)
+OPERATOR_IMAGE_VERSION ?= $(shell awk '/^appVersion:/ {print $$2; exit}' helm/xtrinode-operator/Chart.yaml 2>/dev/null | tr -d '"' || echo "dev")
+GATEWAY_IMAGE_VERSION ?= $(shell awk '/^appVersion:/ {print $$2; exit}' helm/xtrinode-gateway/Chart.yaml 2>/dev/null | tr -d '"' || echo "dev")
+API_SERVER_IMAGE_VERSION ?= $(shell awk '/^appVersion:/ {print $$2; exit}' helm/xtrinode-api-server/Chart.yaml 2>/dev/null | tr -d '"' || echo "dev")
+OPERATOR_IMAGE_TAG ?= $(if $(GIT_TAG),$(OPERATOR_IMAGE_VERSION),dev)
+GATEWAY_IMAGE_TAG ?= $(if $(GIT_TAG),$(GATEWAY_IMAGE_VERSION),dev)
+API_SERVER_IMAGE_TAG ?= $(if $(GIT_TAG),$(API_SERVER_IMAGE_VERSION),dev)
+OPERATOR_CLOUD_IMAGE_TAG ?= $(if $(filter dev,$(OPERATOR_IMAGE_TAG)),$(OPERATOR_IMAGE_VERSION),$(OPERATOR_IMAGE_TAG))
+GATEWAY_CLOUD_IMAGE_TAG ?= $(if $(filter dev,$(GATEWAY_IMAGE_TAG)),$(GATEWAY_IMAGE_VERSION),$(GATEWAY_IMAGE_TAG))
+API_SERVER_CLOUD_IMAGE_TAG ?= $(if $(filter dev,$(API_SERVER_IMAGE_TAG)),$(API_SERVER_IMAGE_VERSION),$(API_SERVER_IMAGE_TAG))
+IMG ?= $(REGISTRY)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_IMAGE_TAG)
+GATEWAY_IMG ?= $(REGISTRY)/$(GATEWAY_IMAGE_NAME):$(GATEWAY_IMAGE_TAG)
+API_SERVER_IMG ?= $(REGISTRY)/$(API_SERVER_IMAGE_NAME):$(API_SERVER_IMAGE_TAG)
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -235,12 +241,18 @@ help: ## Display this help message
 	@echo "Variables:"
 	@echo "  REGISTRY             Docker registry/repository prefix (default: ghcr.io/xtrinode)"
 	@echo "  OPERATOR_IMAGE_NAME  Operator image name (default: xtrinode-operator)"
-	@echo "  IMG                  Operator image tag (default: \$${REGISTRY}/\$${OPERATOR_IMAGE_NAME}:\$${IMAGE_TAG})"
+	@echo "  IMG                  Operator image tag (default: \$${REGISTRY}/\$${OPERATOR_IMAGE_NAME}:\$${OPERATOR_IMAGE_TAG})"
 	@echo "  GIT_TAG              Exact git tag at HEAD, when present"
-	@echo "  VERSION              Version tag (default: exact git tag without leading v, or 'dev')"
-	@echo "  IMAGE_VERSION        Component image version from Helm appVersion (default: umbrella appVersion)"
-	@echo "  IMAGE_TAG            Docker image tag (default: appVersion on exact release tags, otherwise \$${VERSION})"
-	@echo "  CLOUD_IMAGE_TAG      Cloud publish/deploy tag (default: appVersion when IMAGE_TAG is dev)"
+	@echo "  VERSION              Binary/release metadata only; not a Docker image tag"
+	@echo "  OPERATOR_IMAGE_VERSION   Operator image version from Helm appVersion"
+	@echo "  GATEWAY_IMAGE_VERSION    Gateway image version from Helm appVersion"
+	@echo "  API_SERVER_IMAGE_VERSION API server image version from Helm appVersion"
+	@echo "  OPERATOR_IMAGE_TAG   Operator Docker image tag"
+	@echo "  GATEWAY_IMAGE_TAG    Gateway Docker image tag"
+	@echo "  API_SERVER_IMAGE_TAG API server Docker image tag"
+	@echo "  OPERATOR_CLOUD_IMAGE_TAG   Operator cloud image tag"
+	@echo "  GATEWAY_CLOUD_IMAGE_TAG    Gateway cloud image tag"
+	@echo "  API_SERVER_CLOUD_IMAGE_TAG API server cloud image tag"
 	@echo "  GO_VERSION           Go toolchain/image version (default: 1.26.3)"
 	@echo "  ALPINE_VERSION       Alpine image version (default: 3.23)"
 	@echo "  DOCKER_PLATFORMS     buildx platforms (default: linux/amd64)"
@@ -255,8 +267,8 @@ help: ## Display this help message
 	@echo ""
 	@echo "Tooling: make tool-versions and docs/TOOLING.md show required local versions."
 	@echo "Deployment: make deploy-gcp | make deploy-aws | make deploy-azure | make deploy"
-	@echo "Docker release: git tag v0.1.0 && make docker-release"
-	@echo "Release GCP: make release-operator-gcp VERSION=0.1.0  (build, push, rollout)"
+	@echo "Docker release: CI publishes changed component appVersions; use docker-buildx-<component> for manual pushes"
+	@echo "GCP images: make gcp-images-push OPERATOR_CLOUD_IMAGE_TAG=0.1.0 GATEWAY_CLOUD_IMAGE_TAG=0.1.0 API_SERVER_CLOUD_IMAGE_TAG=0.1.0"
 	@echo "See docs/DEPLOYMENT.md for full flow."
 
 # =============================================================================
@@ -844,7 +856,7 @@ define docker_build
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg APP_PACKAGE=$($(3)_PACKAGE) \
 		--build-arg APP_PORT=$($(3)_PORT) \
-		--build-arg VERSION=$(IMAGE_TAG) \
+		--build-arg VERSION=$($(3)_IMAGE_TAG) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
 		-t $($(2)) \
@@ -867,7 +879,7 @@ define docker_buildx
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg APP_PACKAGE=$($(3)_PACKAGE) \
 		--build-arg APP_PORT=$($(3)_PORT) \
-		--build-arg VERSION=$(IMAGE_TAG) \
+		--build-arg VERSION=$($(3)_IMAGE_TAG) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg BUILD_DATE=$(BUILD_DATE) \
 		-t $($(2)) \
@@ -927,26 +939,12 @@ docker-buildx-gateway: docker-buildx-builder ## Build gateway Docker image with 
 docker-buildx-api-server: docker-buildx-builder ## Build API server Docker image with buildx
 	$(call docker_buildx,API server,API_SERVER_IMG,API_SERVER)
 
-.PHONY: require-release-tag
-require-release-tag:
-	@if [ -z "$(GIT_TAG)" ]; then \
-		echo "ERROR: release targets must run from an exact git tag."; \
-		echo "Create and check out a release tag, for example: git tag v$$(awk '/^version:/ {print $$2; exit}' $(UMBRELLA_HELM_CHART_PATH)/Chart.yaml | tr -d '\"')"; \
-		exit 1; \
-	fi
-	@tag_version="$(GIT_TAG)"; tag_version="$${tag_version#v}"; \
-	if [ "$(VERSION)" != "$$tag_version" ]; then \
-		echo "ERROR: VERSION ($(VERSION)) does not match git tag $(GIT_TAG) ($$tag_version)."; \
-		exit 1; \
-	fi
-	@if [ "$(IMAGE_TAG)" != "$(IMAGE_VERSION)" ]; then \
-		echo "ERROR: IMAGE_TAG ($(IMAGE_TAG)) must match IMAGE_VERSION ($(IMAGE_VERSION)) for release targets."; \
-		exit 1; \
-	fi
-
 .PHONY: docker-release
-docker-release: require-release-tag ## Build and push all Docker release images from the exact git tag
-	$(MAKE) docker-buildx
+docker-release: ## Refuse manual release publishing; CI publishes changed component images
+	@echo "ERROR: Docker release publishing is CI-owned and component-scoped."
+	@echo "Update the relevant component chart appVersion and merge through the release workflow."
+	@echo "For manual non-release pushes, use docker-buildx-operator, docker-buildx-gateway, or docker-buildx-api-server with explicit component image tags."
+	@exit 1
 
 # =============================================================================
 # Kubernetes Deployment Commands
@@ -975,47 +973,35 @@ GCP_API_SERVER_IMAGE ?= $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/xtrinode-
 gcp-docker-login: ## Configure Docker auth for GCP Artifact Registry
 	$(GCLOUD) auth configure-docker $(GCP_REGION)-docker.pkg.dev --quiet
 
+define gcp_image_push
+	@echo "Building and pushing GCP $(1) image with tag $($(2)_CLOUD_IMAGE_TAG)..."
+	$(DOCKER) build --build-arg GO_VERSION=$(GO_VERSION) --build-arg ALPINE_VERSION=$(ALPINE_VERSION) --build-arg APP_PACKAGE=$($(2)_PACKAGE) --build-arg APP_PORT=$($(2)_PORT) --build-arg VERSION=$($(2)_CLOUD_IMAGE_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg BUILD_DATE=$(BUILD_DATE) -t $($(3)):$($(2)_CLOUD_IMAGE_TAG) -f $($(2)_DOCKERFILE) $(OPERATOR_DIR)
+	$(DOCKER) push $($(3)):$($(2)_CLOUD_IMAGE_TAG)
+	@echo "GCP $(1) image pushed."
+endef
+
 .PHONY: gcp-images-push
 gcp-images-push: gcp-docker-login ## Build and push all XTrinode images to GCP Artifact Registry
-	@echo "Building and pushing GCP images with tag $(CLOUD_IMAGE_TAG)..."
-	$(DOCKER) build --build-arg GO_VERSION=$(GO_VERSION) --build-arg ALPINE_VERSION=$(ALPINE_VERSION) --build-arg APP_PACKAGE=$(OPERATOR_PACKAGE) --build-arg APP_PORT=$(OPERATOR_PORT) --build-arg VERSION=$(CLOUD_IMAGE_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg BUILD_DATE=$(BUILD_DATE) -t $(GCP_OPERATOR_IMAGE):$(CLOUD_IMAGE_TAG) -f $(OPERATOR_DOCKERFILE) $(OPERATOR_DIR)
-	$(DOCKER) push $(GCP_OPERATOR_IMAGE):$(CLOUD_IMAGE_TAG)
-	$(DOCKER) build --build-arg GO_VERSION=$(GO_VERSION) --build-arg ALPINE_VERSION=$(ALPINE_VERSION) --build-arg APP_PACKAGE=$(GATEWAY_PACKAGE) --build-arg APP_PORT=$(GATEWAY_PORT) --build-arg VERSION=$(CLOUD_IMAGE_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg BUILD_DATE=$(BUILD_DATE) -t $(GCP_GATEWAY_IMAGE):$(CLOUD_IMAGE_TAG) -f $(GATEWAY_DOCKERFILE) $(OPERATOR_DIR)
-	$(DOCKER) push $(GCP_GATEWAY_IMAGE):$(CLOUD_IMAGE_TAG)
-	$(DOCKER) build --build-arg GO_VERSION=$(GO_VERSION) --build-arg ALPINE_VERSION=$(ALPINE_VERSION) --build-arg APP_PACKAGE=$(API_SERVER_PACKAGE) --build-arg APP_PORT=$(API_SERVER_PORT) --build-arg VERSION=$(CLOUD_IMAGE_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg BUILD_DATE=$(BUILD_DATE) -t $(GCP_API_SERVER_IMAGE):$(CLOUD_IMAGE_TAG) -f $(API_SERVER_DOCKERFILE) $(OPERATOR_DIR)
-	$(DOCKER) push $(GCP_API_SERVER_IMAGE):$(CLOUD_IMAGE_TAG)
+	@echo "Building and pushing GCP images:"
+	@echo "  operator:   $(OPERATOR_CLOUD_IMAGE_TAG)"
+	@echo "  gateway:    $(GATEWAY_CLOUD_IMAGE_TAG)"
+	@echo "  api-server: $(API_SERVER_CLOUD_IMAGE_TAG)"
+	$(call gcp_image_push,operator,OPERATOR,GCP_OPERATOR_IMAGE)
+	$(call gcp_image_push,gateway,GATEWAY,GCP_GATEWAY_IMAGE)
+	$(call gcp_image_push,API server,API_SERVER,GCP_API_SERVER_IMAGE)
 	@echo "GCP images pushed."
 
 .PHONY: gcp-operator-image-push
 gcp-operator-image-push: gcp-docker-login ## Build and push only the XTrinode operator image to GCP Artifact Registry
-	@echo "Building and pushing GCP operator image with tag $(CLOUD_IMAGE_TAG)..."
-	$(DOCKER) build --build-arg GO_VERSION=$(GO_VERSION) --build-arg ALPINE_VERSION=$(ALPINE_VERSION) --build-arg APP_PACKAGE=$(OPERATOR_PACKAGE) --build-arg APP_PORT=$(OPERATOR_PORT) --build-arg VERSION=$(CLOUD_IMAGE_TAG) --build-arg GIT_COMMIT=$(GIT_COMMIT) --build-arg BUILD_DATE=$(BUILD_DATE) -t $(GCP_OPERATOR_IMAGE):$(CLOUD_IMAGE_TAG) -f $(OPERATOR_DOCKERFILE) $(OPERATOR_DIR)
-	$(DOCKER) push $(GCP_OPERATOR_IMAGE):$(CLOUD_IMAGE_TAG)
-	@echo "GCP operator image pushed."
+	$(call gcp_image_push,operator,OPERATOR,GCP_OPERATOR_IMAGE)
 
-.PHONY: release-operator-gcp
-release-operator-gcp: ## Build operator, push to GCP Artifact Registry, helm upgrade, rollout restart. Set CLOUD_IMAGE_TAG for tag (default: appVersion for cloud publishes).
-	@echo "=== Release operator to GCP ==="
-	@echo "Tag: $(CLOUD_IMAGE_TAG)"
-	$(MAKE) docker-build-operator IMAGE_TAG=$(CLOUD_IMAGE_TAG) IMG=$(REGISTRY)/$(OPERATOR_IMAGE_NAME):$(CLOUD_IMAGE_TAG)
-	$(DOCKER) tag $(REGISTRY)/$(OPERATOR_IMAGE_NAME):$(CLOUD_IMAGE_TAG) $(GCP_REGISTRY):$(CLOUD_IMAGE_TAG)
-	$(DOCKER) push $(GCP_REGISTRY):$(CLOUD_IMAGE_TAG)
-	@echo "Configuring kubectl for GKE..."
-	$(GCLOUD) container clusters get-credentials $(GCP_CLUSTER_NAME) --zone $(GCP_ZONE) --project $(GCP_PROJECT_ID)
-	@echo "Generating and applying CRDs..."
-	$(MAKE) manifests
-	$(KUBECTL) apply -f $(HELM_CHART_PATH)/crds
-	@echo "Upgrading Helm release..."
-	$(HELM) upgrade --install xtrinode-operator $(HELM_CHART_PATH) \
-		-n $(GCP_OPERATOR_NAMESPACE) \
-		--set image.repository=$(GCP_REGISTRY) \
-		--set image.tag=$(CLOUD_IMAGE_TAG) \
-		--set image.pullPolicy=Always \
-		--reuse-values
-	@echo "Restarting operator deployment..."
-	$(KUBECTL) rollout restart deployment xtrinode-operator -n $(GCP_OPERATOR_NAMESPACE)
-	$(KUBECTL) rollout status deployment xtrinode-operator -n $(GCP_OPERATOR_NAMESPACE) --timeout=120s
-	@echo "=== Release complete ==="
+.PHONY: gcp-gateway-image-push
+gcp-gateway-image-push: gcp-docker-login ## Build and push only the XTrinode gateway image to GCP Artifact Registry
+	$(call gcp_image_push,gateway,GATEWAY,GCP_GATEWAY_IMAGE)
+
+.PHONY: gcp-api-server-image-push
+gcp-api-server-image-push: gcp-docker-login ## Build and push only the XTrinode API server image to GCP Artifact Registry
+	$(call gcp_image_push,API server,API_SERVER,GCP_API_SERVER_IMAGE)
 
 .PHONY: deploy-aws
 deploy-aws: helm-repo-setup ## Experimental AWS provider-validation deploy: terraform + build + push + helm.
@@ -1032,7 +1018,7 @@ deploy-operator: manifests helm-deps ## Deploy operator (includes KEDA subchart 
 		-n $(OPERATOR_NAMESPACE) \
 		--create-namespace \
 		--set image.repository=$(REGISTRY)/$(OPERATOR_IMAGE_NAME) \
-		--set image.tag=$(IMAGE_TAG) \
+		--set image.tag=$(OPERATOR_IMAGE_TAG) \
 		--wait
 	@echo "Operator deployment complete"
 
@@ -1043,7 +1029,7 @@ deploy-api-server: ## Deploy API server to xtrinode-system namespace via Helm
 		-n $(API_SERVER_NAMESPACE) \
 		--create-namespace \
 		--set image.repository=$(REGISTRY)/$(API_SERVER_IMAGE_NAME) \
-		--set image.tag=$(IMAGE_TAG) \
+		--set image.tag=$(API_SERVER_IMAGE_TAG) \
 		--wait
 	@echo "API server deployment complete"
 
@@ -1054,7 +1040,7 @@ deploy-gateway: ## Deploy gateway to xtrinode-gateway namespace via Helm
 		-n $(GATEWAY_NAMESPACE) \
 		--create-namespace \
 		--set image.repository=$(REGISTRY)/$(GATEWAY_IMAGE_NAME) \
-		--set image.tag=$(IMAGE_TAG) \
+		--set image.tag=$(GATEWAY_IMAGE_TAG) \
 		--wait
 	@echo "Gateway deployment complete"
 
@@ -1105,7 +1091,7 @@ upgrade-operator: ## Upgrade operator deployment
 	$(HELM) upgrade $(RELEASE_NAME) $(HELM_CHART_PATH) \
 		-n $(OPERATOR_NAMESPACE) \
 		--set image.repository=$(REGISTRY)/$(OPERATOR_IMAGE_NAME) \
-		--set image.tag=$(IMAGE_TAG) \
+		--set image.tag=$(OPERATOR_IMAGE_TAG) \
 		--wait
 	@echo "Operator upgrade complete"
 
@@ -1115,7 +1101,7 @@ upgrade-api-server: ## Upgrade API server deployment
 	$(HELM) upgrade xtrinode-api-server $(API_SERVER_HELM_CHART_PATH) \
 		-n $(API_SERVER_NAMESPACE) \
 		--set image.repository=$(REGISTRY)/$(API_SERVER_IMAGE_NAME) \
-		--set image.tag=$(IMAGE_TAG) \
+		--set image.tag=$(API_SERVER_IMAGE_TAG) \
 		--wait
 	@echo "API server upgrade complete"
 
@@ -1125,7 +1111,7 @@ upgrade-gateway: ## Upgrade gateway deployment
 	$(HELM) upgrade xtrinode-gateway $(GATEWAY_HELM_CHART_PATH) \
 		-n $(GATEWAY_NAMESPACE) \
 		--set image.repository=$(REGISTRY)/$(GATEWAY_IMAGE_NAME) \
-		--set image.tag=$(IMAGE_TAG) \
+		--set image.tag=$(GATEWAY_IMAGE_TAG) \
 		--wait
 	@echo "Gateway upgrade complete"
 
@@ -1417,7 +1403,7 @@ gcp-observability-up: gcp-configure-kubectl install-observability ## Install Pro
 .PHONY: gcp-control-plane-deploy
 gcp-control-plane-deploy: gcp-configure-kubectl ## Deploy XTrinode operator, API server, and gateway to the management cluster
 	@echo "Deploying XTrinode control plane to GCP management cluster..."
-	GCP_PROJECT_ID=$(GCP_PROJECT_ID) GCP_REGION=$(GCP_REGION) GCP_ZONE=$(GCP_ZONE) GCP_CLUSTER_NAME=$(GCP_CLUSTER_NAME) OPERATOR_NAMESPACE=$(GCP_OPERATOR_NAMESPACE) VERSION=$(VERSION) GATEWAY_REPLICA_COUNT=$(GATEWAY_REPLICA_COUNT) GATEWAY_REDIS_ENABLED=$(GATEWAY_REDIS_ENABLED) PROMETHEUS_ENABLED=$(PROMETHEUS_ENABLED) PROMETHEUS_STORAGE_CLASS=$(PROMETHEUS_STORAGE_CLASS) VECTOR_ENABLED=$(VECTOR_ENABLED) VECTOR_NAMESPACE=$(VECTOR_NAMESPACE) VECTOR_LOG_LEVEL=$(VECTOR_LOG_LEVEL) WEBHOOK_ENABLED=$(WEBHOOK_ENABLED) HELM="$(HELM)" KUBECTL="$(KUBECTL)" GCLOUD="$(GCLOUD)" OPENSSL="$(OPENSSL)" bash scripts/deploy-gcp.sh
+	GCP_PROJECT_ID=$(GCP_PROJECT_ID) GCP_REGION=$(GCP_REGION) GCP_ZONE=$(GCP_ZONE) GCP_CLUSTER_NAME=$(GCP_CLUSTER_NAME) OPERATOR_NAMESPACE=$(GCP_OPERATOR_NAMESPACE) OPERATOR_IMAGE_TAG=$(OPERATOR_CLOUD_IMAGE_TAG) API_SERVER_IMAGE_TAG=$(API_SERVER_CLOUD_IMAGE_TAG) GATEWAY_IMAGE_TAG=$(GATEWAY_CLOUD_IMAGE_TAG) GATEWAY_REPLICA_COUNT=$(GATEWAY_REPLICA_COUNT) GATEWAY_REDIS_ENABLED=$(GATEWAY_REDIS_ENABLED) PROMETHEUS_ENABLED=$(PROMETHEUS_ENABLED) PROMETHEUS_STORAGE_CLASS=$(PROMETHEUS_STORAGE_CLASS) VECTOR_ENABLED=$(VECTOR_ENABLED) VECTOR_NAMESPACE=$(VECTOR_NAMESPACE) VECTOR_LOG_LEVEL=$(VECTOR_LOG_LEVEL) WEBHOOK_ENABLED=$(WEBHOOK_ENABLED) HELM="$(HELM)" KUBECTL="$(KUBECTL)" GCLOUD="$(GCLOUD)" OPENSSL="$(OPENSSL)" bash scripts/deploy-gcp.sh
 
 .PHONY: gcp-gateway-redis-up
 gcp-gateway-redis-up: ## Redeploy gateway with in-chart Redis enabled
@@ -1572,13 +1558,9 @@ godeps-vendor: ## Vendor dependencies
 # =============================================================================
 
 .PHONY: release
-release: require-release-tag ci-lint ci-test ci-verify-manifests ci-terraform-validate-all ci-security docker-build ## Validate release locally from an exact git tag
-	@echo "Validating release $(VERSION)..."
-	@if [ "$(VERSION)" = "dev" ]; then \
-		echo "ERROR: VERSION is 'dev'. Set VERSION to the release version."; \
-		exit 1; \
-	fi
-	@echo "Release $(VERSION) validated from tag $(GIT_TAG). A CODEOWNER must open and merge the release PR."
+release: ci-lint ci-test ci-verify-manifests ci-terraform-validate-all ci-security docker-build ## Validate release readiness locally without publishing
+	@bash -c 'source scripts/ci/release-lib.sh; validate_release_version_metadata'
+	@echo "Release readiness validated locally. Merge a CODEOWNER-owned release PR to publish."
 
 .PHONY: release-notes
 release-notes: ## Generate release notes from git commits
@@ -1666,18 +1648,19 @@ ci-tool-versions-output: ## Write CI tool versions to GITHUB_OUTPUT
 	@printf 'clusterctl=%s\n' "$(CLUSTERCTL_VERSION)" >> "$$GITHUB_OUTPUT"
 	@printf 'capg=%s\n' "$(CAPG_VERSION)" >> "$$GITHUB_OUTPUT"
 
-.PHONY: ci-image-matrix-output
-ci-image-matrix-output: ## Write the Docker image matrix to GITHUB_OUTPUT
-	@: "$${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
-	@printf 'matrix={"include":[{"component":"operator","image":"%s","package":"%s","port":"%s"},{"component":"gateway","image":"%s","package":"%s","port":"%s"},{"component":"api-server","image":"%s","package":"%s","port":"%s"}]}\n' \
-		"$(OPERATOR_IMAGE_NAME)" "$(OPERATOR_PACKAGE)" "$(OPERATOR_PORT)" \
-		"$(GATEWAY_IMAGE_NAME)" "$(GATEWAY_PACKAGE)" "$(GATEWAY_PORT)" \
-		"$(API_SERVER_IMAGE_NAME)" "$(API_SERVER_PACKAGE)" "$(API_SERVER_PORT)" >> "$$GITHUB_OUTPUT"
-
 .PHONY: ci-build-date-output
-ci-build-date-output: ## Write an RFC3339 UTC build timestamp to GITHUB_OUTPUT
+ci-build-date-output: ## Write the release commit timestamp to GITHUB_OUTPUT
 	@: "$${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
-	@printf 'value=%s\n' "$$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$$GITHUB_OUTPUT"
+	@timestamp="$$(git show -s --format=%ct HEAD 2>/dev/null || true)"; \
+	if [ -n "$$timestamp" ]; then \
+		printf 'value=%s\n' "$$(date -u -d "@$$timestamp" +'%Y-%m-%dT%H:%M:%SZ')" >> "$$GITHUB_OUTPUT"; \
+	else \
+		printf 'value=%s\n' "$$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$$GITHUB_OUTPUT"; \
+	fi
+
+.PHONY: ci-release-image-preflight
+ci-release-image-preflight: ## Refuse conflicting exact image tags before release image publishing
+	scripts/ci/release-image-preflight.sh
 
 .PHONY: ci-release-pr-policy
 ci-release-pr-policy: ## Validate CODEOWNER release PR policy
@@ -1702,11 +1685,15 @@ ci-package-helm-release: ## Package all release Helm charts (usage: RELEASE_VERS
 		echo "ERROR: RELEASE_VERSION is required"; \
 		exit 1; \
 	fi
+	@if [ "$$(awk '/^version:/ {print $$2; exit}' "$(UMBRELLA_HELM_CHART_PATH)/Chart.yaml" | tr -d '\"')" != "$(RELEASE_VERSION)" ]; then \
+		echo "ERROR: RELEASE_VERSION ($(RELEASE_VERSION)) must match umbrella chart version"; \
+		exit 1; \
+	fi
 	mkdir -p dist
-	$(HELM) package "$(UMBRELLA_HELM_CHART_PATH)" --version "$(RELEASE_VERSION)" --app-version "$(IMAGE_VERSION)" --destination dist/
-	$(HELM) package "$(HELM_CHART_PATH)" --version "$(RELEASE_VERSION)" --app-version "$(IMAGE_VERSION)" --destination dist/
-	$(HELM) package "$(API_SERVER_HELM_CHART_PATH)" --version "$(RELEASE_VERSION)" --app-version "$(IMAGE_VERSION)" --destination dist/
-	$(HELM) package "$(GATEWAY_HELM_CHART_PATH)" --version "$(RELEASE_VERSION)" --app-version "$(IMAGE_VERSION)" --destination dist/
+	$(HELM) package "$(UMBRELLA_HELM_CHART_PATH)" --destination dist/
+	$(HELM) package "$(HELM_CHART_PATH)" --destination dist/
+	$(HELM) package "$(API_SERVER_HELM_CHART_PATH)" --destination dist/
+	$(HELM) package "$(GATEWAY_HELM_CHART_PATH)" --destination dist/
 
 .PHONY: ci-release-notes
 ci-release-notes: ## Write release notes to GITHUB_OUTPUT

--- a/docs/CODEOWNERS.md
+++ b/docs/CODEOWNERS.md
@@ -36,27 +36,32 @@ top-level ownership rules should be added when the corresponding root path is in
 Releases are intentionally tied to merged pull requests, not manual tag pushes.
 
 1. An explicit CODEOWNER opens a pull request from a branch owned by an explicit CODEOWNER. The PR
-   bumps the Helm chart version to the intended SemVer version.
+   changes release metadata: the umbrella Helm chart version, a component chart version, or an
+   operator, API server, or gateway chart `appVersion`.
 2. CI must pass on the pull request.
 3. A CODEOWNER must approve the pull request.
 4. A CODEOWNER must merge the pull request into `main`.
-5. The release workflow creates the missing `vMAJOR.MINOR.PATCH` tag from the chart version, builds
-   release images, packages Helm charts, and creates the GitHub Release.
+5. The release workflow creates the missing `v<umbrella-version>` tag only when the umbrella chart
+   version changes, packages Helm charts only for that umbrella release, and publishes only the
+   component images whose `appVersion` changed.
 
 The CI workflow checks the release PR author and branch owner against explicit individual owners in
-`.github/CODEOWNERS`, and it validates that every XTrinode chart `version` and umbrella dependency
-version matches the intended XTrinode SemVer release. The operator, API server, gateway, and
-umbrella chart `appVersion` fields must match that same XTrinode release version. The managed Trino
-runtime image tag is pinned separately and must not be used as a control-plane image tag. The release
-workflow repeats those owner checks, also checks the user who merged the pull request, and reuses the
-same version metadata validation. Team ownership is still useful for review enforcement, but release
-authoring, branch ownership, and merging need individual CODEOWNER entries unless the workflows are
-extended to resolve team membership.
+`.github/CODEOWNERS`, and it validates release metadata. The umbrella chart dependency versions must
+match the corresponding operator, API server, and gateway chart `version` fields, but component chart
+versions may differ from the umbrella chart version. The operator, API server, and gateway
+`appVersion` fields are independent Docker image versions. The managed Trino runtime image tag is
+pinned separately and must not be used as a control-plane image tag. The release workflow repeats
+those owner checks, also checks the user who merged the pull request, and reuses the same version
+metadata validation. Team ownership is still useful for review enforcement, but release authoring,
+branch ownership, and merging need individual CODEOWNER entries unless the workflows are extended to
+resolve team membership.
 
 `Release PR Policy` must be configured as a required check on `main`; workflow logic cannot enforce
 that requirement by itself. CODEOWNER approval is enforced by GitHub branch protection or rulesets,
 not by the workflow file.
 
-If the chart version does not change, the release workflow skips publishing. If a PR changes the
-version to one that already has a matching tag, the workflow fails so the release version can be
-corrected before publishing.
+If the umbrella chart version does not change, the release workflow does not create a Git tag or
+GitHub Release. Docker images can still publish from the merge commit without a release tag when one
+or more component `appVersion` fields change. If a PR changes the umbrella chart version to one that
+already has a matching tag, the workflow fails so the release version can be corrected before
+publishing.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -97,8 +97,8 @@ cluster. The script first tries regional credentials with `--region
 $GCP_REGION`, then zonal credentials with `--zone $GCP_ZONE`.
 
 Images are resolved from `${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}`, so
-the pushed image repositories and `VERSION` tag must exist in that region before
-deploying to an arbitrary cluster.
+the pushed image repositories and component image tags must exist in that region
+before deploying to an arbitrary cluster.
 
 Using an existing GKE node pool for Trino pods is a runtime-level setting, not a
 control-plane deploy setting. For an existing node pool, leave
@@ -123,7 +123,9 @@ pod placement to the managed pool label.
 | `GCP_PROJECT_ID` | project-40642592-0c4f-4ce1-9d6 | GCP project |
 | `GCP_CLUSTER_NAME` | xtrinode-gke-test | GKE cluster name |
 | `GCP_ZONE` | us-central1-a | GKE zone |
-| `VERSION` | 0.1.0 | Image tag |
+| `OPERATOR_IMAGE_TAG` | operator chart appVersion | Operator image tag |
+| `API_SERVER_IMAGE_TAG` | API server chart appVersion | API server image tag |
+| `GATEWAY_IMAGE_TAG` | gateway chart appVersion | Gateway image tag |
 | `OPERATOR_NAMESPACE` | xtrinode-system | Namespace for operator + API server |
 
 ---
@@ -182,7 +184,9 @@ Key environment variables:
 | `AWS_PROFILE` | default | AWS CLI profile |
 | `AWS_REGION` | us-east-1 | AWS region |
 | `CLUSTER_NAME` | xtrinode-eks-test | EKS cluster name |
-| `VERSION` | chart appVersion | Image tag |
+| `OPERATOR_IMAGE_TAG` | operator chart appVersion | Operator image tag |
+| `API_SERVER_IMAGE_TAG` | API server chart appVersion | API server image tag |
+| `GATEWAY_IMAGE_TAG` | gateway chart appVersion | Gateway image tag |
 | `POSTGRES_ENABLED` / `TF_VAR_postgres_enabled` | false | Enable RDS PostgreSQL catalog-test infrastructure |
 | `PROMETHEUS_ENABLED` | false | Install observability and render ServiceMonitors |
 | `VECTOR_ENABLED` | false | Install Vector through the observability chart |
@@ -248,7 +252,9 @@ Key environment variables:
 | `RESOURCE_GROUP_NAME` | xtrinode-rg | Azure resource group |
 | `CLUSTER_NAME` | xtrinode-aks-test | AKS cluster name |
 | `ACR_LOGIN_SERVER` | Terraform output | ACR login server override |
-| `VERSION` | chart appVersion | Image tag |
+| `OPERATOR_IMAGE_TAG` | operator chart appVersion | Operator image tag |
+| `API_SERVER_IMAGE_TAG` | API server chart appVersion | API server image tag |
+| `GATEWAY_IMAGE_TAG` | gateway chart appVersion | Gateway image tag |
 | `POSTGRES_ENABLED` / `TF_VAR_postgres_enabled` | false | Enable Azure PostgreSQL catalog-test infrastructure |
 | `PROMETHEUS_ENABLED` | false | Install observability and render ServiceMonitors |
 | `VECTOR_ENABLED` | false | Install Vector through the observability chart |
@@ -311,6 +317,7 @@ node-pool policy knobs.
 | `make terraform-apply-gcp` | Apply the GCP Terraform deployment |
 | `make gcp-management-up` | Create the GCP management cluster and Kubernetes/cloud add-ons |
 | `make gcp-images-push` | Build and push operator, API server, and gateway images to GCP Artifact Registry |
+| `make gcp-operator-image-push` / `make gcp-api-server-image-push` / `make gcp-gateway-image-push` | Build and push one GCP component image |
 | `make gcp-control-plane-deploy` | Deploy operator, API server, and gateway to the GCP management cluster |
 | `make deploy-gcp` | Full GCP deploy via scripts/deploy-gcp.sh |
 | `make deploy-aws` | Experimental AWS provider-validation deploy via scripts/deploy-aws.sh |

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -27,6 +27,7 @@ make tool-versions
 | Node.js | `>=22` | Markdown tooling | `.nvmrc`, `package.json`, `NODE_VERSION` |
 | npm | `10.9.7` | Local JavaScript tool install and scripts | `package.json` `packageManager` |
 | markdownlint-cli | `0.48.0` | `make lint-markdown` | `package.json`, `package-lock.json`, `MARKDOWNLINT_CLI_VERSION` |
+| pre-commit | Current stable | Local Git hooks for fast Make-backed checks | `.pre-commit-config.yaml`, `PRE_COMMIT` |
 | Docker with Buildx | Current stable | Image builds, k3d, local registry workflows | Local install |
 | Helm | `v3.20.0` | Helm dependency, lint, template, deploy targets | `HELM_VERSION` |
 | kubectl | `v1.34.8` | Cluster and deploy targets | `KUBECTL_VERSION` |
@@ -115,6 +116,24 @@ npm ci
 `make lint-markdown` delegates to `npm run lint:markdown`. It does not use a globally installed `markdownlint`, `npx`,
 or a Docker image. If `npm ci` has not been run, the target should fail instead of downloading a fallback linter.
 
+## Local Git Hooks
+
+The repository uses `pre-commit` for fast local checks. Install `pre-commit` with your system or Python tooling, then
+install the hook:
+
+```bash
+make pre-commit-install
+```
+
+Run the same hooks across the repository with:
+
+```bash
+make pre-commit-run
+```
+
+The hooks delegate to existing Make targets for shell syntax, YAML parsing, Markdown lint, and release metadata checks.
+They do not install missing tools or replace the broader CI targets.
+
 ## Local Stack Binaries
 
 The local k3d/Tilt/e2e workflow defaults to repository-local binaries:
@@ -141,7 +160,7 @@ make dev-up K3D=/opt/bin/k3d TILT=/opt/bin/tilt UV=/opt/bin/uv HELM=/opt/bin/hel
 
 Supported command variables include `GO`, `GOFMT`, `GO_TOOL_BIN`, `GOLANGCI_LINT`, `CONTROLLER_GEN`, `SETUP_ENVTEST`,
 `RUBY`, `NPM`, `HELM`, `KUBECTL`, `TERRAFORM`, `TFLINT`, `K3D`, `TILT`, `UV`, `DOCKER`, `AWS`, `AZ`, `GCLOUD`,
-`CURL`, `OPENSSL`, `CLUSTERCTL`, `TRIVY`, `MAKE_CMD`, `GODOC`, and `OPEN`.
+`CURL`, `OPENSSL`, `CLUSTERCTL`, `TRIVY`, `MAKE_CMD`, `GODOC`, `OPEN`, and `PRE_COMMIT`.
 
 ## CI Setup
 

--- a/docs/TOOLING.md
+++ b/docs/TOOLING.md
@@ -66,8 +66,8 @@ Override `GOLANGCI_LINT`, `CONTROLLER_GEN`, `SETUP_ENVTEST`, or `GODOC` when usi
 | controller-runtime | `v0.22.4` | `xtrinode/go.mod` replace directives |
 | KEDA API types | `github.com/kedacore/keda/v2 v2.19.0` | `xtrinode/go.mod` |
 | KEDA Helm chart | `2.19.0` | `helm/xtrinode-operator/Chart.yaml` |
-| XTrinode Helm chart version | `0.1.0` | `helm/xtrinode*/Chart.yaml` `version` fields and umbrella dependencies |
-| XTrinode component image version | `0.1.0` | `helm/xtrinode*/Chart.yaml` `appVersion` fields |
+| XTrinode umbrella chart version | `0.1.0` | `helm/xtrinode/Chart.yaml` `version` field |
+| XTrinode component image versions | `0.1.0` | Operator, API server, and gateway chart `appVersion` fields |
 | Default Trino runtime image tag | `480` | `TRINO_IMAGE_TAG`, `internal/config` |
 | Trino runtime compatibility target | `trino-1.42.2` / app `480` | Upstream Trino chart reference and runtime image pin |
 
@@ -93,9 +93,11 @@ e2e run covering both metrics-api and Prometheus-backed scaling.
 - For KEDA 2.19.0, keep the main module's Go `replace` directives aligned with KEDA's Kubernetes `v0.34.3` and
   controller-runtime `v0.22.4` pins. Dependency module `replace` directives do not propagate into this module.
 - Revisit the KEDA-aligned `replace` directives only when the imported KEDA Go API no longer needs those pins.
-- Keep all XTrinode chart `version` fields and umbrella dependency versions aligned with the XTrinode release version.
-- Keep all XTrinode chart `appVersion` fields aligned with the same XTrinode release version. Do not use the Trino
-  runtime tag or upstream Trino chart version as the operator, API server, or gateway image or chart version.
+- Keep the umbrella chart dependency versions aligned with the corresponding component chart `version` fields.
+- Component chart `version` fields may move independently from the umbrella chart version.
+- Operator, API server, and gateway chart `appVersion` fields are independent Docker image versions and may move
+  independently from each other and from chart versions. Do not use the Trino runtime tag or upstream Trino chart version
+  as the operator, API server, or gateway image or chart version.
 - Treat Trino runtime image/chart drift as an explicit compatibility decision. Catalog property names and metrics exposed
   by Trino can change across Trino releases.
 - Update this file in the same patch as version bumps.

--- a/docs/VERSIONING_AND_PACKAGING.md
+++ b/docs/VERSIONING_AND_PACKAGING.md
@@ -4,25 +4,31 @@
 
 ### **Semantic Versioning**
 
-We use [Semantic Versioning](https://semver.org/) (SemVer) for releases:
+We use Semantic Versioning-style release versions:
 
-- **Format**: `MAJOR.MINOR.PATCH` (e.g., `1.2.3`)
+- **Format**: `MAJOR.MINOR.PATCH` or `MAJOR.MINOR.PATCH-PRERELEASE`
 - **MAJOR**: Breaking changes (incompatible API changes)
 - **MINOR**: New features (backward-compatible)
 - **PATCH**: Bug fixes (backward-compatible)
+- **Build metadata**: `+build` suffixes are not supported because Docker image tags do not support
+  `+`.
 
 ### **Version Sources**
 
 1. **Merged release PR** (Primary):
 
-   - A release PR bumps all XTrinode Helm chart `version` fields, `appVersion` fields, and umbrella
-     dependency versions to the intended XTrinode release.
+   - The umbrella Helm chart `version` controls GitHub Release tags and chart release assets.
+   - Operator, API server, and gateway chart `appVersion` fields control Docker image publishing for
+     each component independently.
+   - Component chart `version` fields may move independently, but umbrella dependency versions must
+     match the corresponding component chart versions.
    - The PR must be opened from a CODEOWNER-owned branch, approved, and merged by a CODEOWNER.
-   - GitHub Actions creates the annotated `vMAJOR.MINOR.PATCH` tag after the merge.
+   - GitHub Actions creates the annotated `v<umbrella-version>` tag after the merge only when the
+     umbrella chart `version` changes.
    - Manual release tag pushes should be blocked with a repository ruleset.
 
-   Docker images are tagged with the XTrinode component image version, for example
-   `ghcr.io/xtrinode/xtrinode-operator:0.1.0`. All XTrinode Helm charts use the same release
+   Docker images are tagged with each component image version, for example
+   `ghcr.io/xtrinode/xtrinode-operator:0.1.0`. GitHub Release assets are tied to the umbrella chart
    version, for example `xtrinode-0.1.0.tgz`.
 
    The managed Trino runtime image is pinned separately, for example `trinodb/trino:480`. That
@@ -32,13 +38,14 @@ We use [Semantic Versioning](https://semver.org/) (SemVer) for releases:
 2. **Makefile Variable**:
 
    ```bash
-   make docker-build VERSION=0.1.0
+   make docker-build OPERATOR_IMAGE_TAG=0.1.0 GATEWAY_IMAGE_TAG=0.1.0 API_SERVER_IMAGE_TAG=0.1.0
    ```
 
 3. **Git Tag Detection**:
-   - Exact `vMAJOR.MINOR.PATCH` tags are used as the default version, with the leading `v` stripped.
+   - Exact `v<release-version>` tags are used as the default version, with the leading `v` stripped.
    - If the current commit is not exactly tagged, the default version is `dev`.
-   - Set `VERSION=0.1.0` explicitly for manual component image builds.
+   - Set `OPERATOR_IMAGE_TAG`, `GATEWAY_IMAGE_TAG`, or `API_SERVER_IMAGE_TAG` explicitly for manual
+     component image builds from an untagged checkout.
 
 ---
 
@@ -52,12 +59,28 @@ We use [Semantic Versioning](https://semver.org/) (SemVer) for releases:
 
 ### **Image Tags**
 
-Multiple tags are created from the component image `appVersion` for each release image push:
+Stable component image `appVersion` releases create these tags:
 
 1. **Version Tag**: `0.1.0` (exact image version)
 2. **Major.Minor Tag**: `0.1` (latest patch for minor version)
 3. **Major Tag**: `0` (latest minor for major version)
 4. **Latest Tag**: `latest` (latest stable release; not created for prereleases)
+
+Image publishing is component-scoped. If only `helm/xtrinode-gateway/Chart.yaml` `appVersion`
+changes, only the gateway image is built, scanned, and pushed.
+
+Patch, minor, and major image releases use the same tagging rules. For example, an appVersion bump
+to `0.1.1` publishes `0.1.1`, `0.1`, `0`, and `latest`; `0.2.0` publishes `0.2.0`, `0.2`, `0`, and
+`latest`; `1.0.0` publishes `1.0.0`, `1.0`, `1`, and `latest`. Prerelease image versions do not
+move floating tags; `1.0.0-rc.1` publishes only `1.0.0-rc.1`. Umbrella prerelease chart versions
+create prerelease GitHub Releases.
+
+Exact image version tags are treated as immutable. Before publishing a component image, release CI
+checks whether `ghcr.io/<owner>/<component-image>:<appVersion>` already exists. If it exists with a
+different `org.opencontainers.image.revision` or version label, CI fails and the component
+`appVersion` must be bumped. If it already exists for the same release commit, CI treats the run as
+a recovery rerun, skips the rebuild and exact-tag push, and restores stable floating tags from the
+existing exact tag.
 
 ### **Architecture Support**
 
@@ -71,20 +94,20 @@ Multiple tags are created from the component image `appVersion` for each release
 
 ```bash
 # Local build
-make docker-build VERSION=0.1.0
+make docker-build OPERATOR_IMAGE_TAG=0.1.0 GATEWAY_IMAGE_TAG=0.1.0 API_SERVER_IMAGE_TAG=0.1.0
 
-# Buildx release publish
-make docker-buildx
+# Manual component Buildx push, outside release automation
+make docker-buildx-operator OPERATOR_IMAGE_TAG=0.1.0 IMG=ghcr.io/xtrinode/xtrinode-operator:0.1.0
 
 # Push to registry
-make docker-push VERSION=0.1.0
+make docker-push OPERATOR_IMAGE_TAG=0.1.0 GATEWAY_IMAGE_TAG=0.1.0 API_SERVER_IMAGE_TAG=0.1.0
 ```
 
 For a single component, use the component-specific targets and image variable:
 
 ```bash
-make docker-build-operator IMG=ghcr.io/xtrinode/xtrinode-operator:0.1.0
-make docker-push-operator IMG=ghcr.io/xtrinode/xtrinode-operator:0.1.0
+make docker-build-operator OPERATOR_IMAGE_TAG=0.1.0 IMG=ghcr.io/xtrinode/xtrinode-operator:0.1.0
+make docker-push-operator OPERATOR_IMAGE_TAG=0.1.0 IMG=ghcr.io/xtrinode/xtrinode-operator:0.1.0
 ```
 
 ---
@@ -94,8 +117,9 @@ make docker-push-operator IMG=ghcr.io/xtrinode/xtrinode-operator:0.1.0
 ### **Chart Version**
 
 - **Location**: `helm/xtrinode/Chart.yaml`
-- **Version**: XTrinode chart package version, for example `0.1.0`
-- **AppVersion**: XTrinode component image version, matching the XTrinode release version
+- **Version**: Chart package version, for example `0.1.0`
+- **AppVersion**: Default component image version for component charts. The umbrella chart
+  `appVersion` is product metadata and does not drive image publishing.
 - **Trino runtime tag**: Managed workload image tag, for example `480`, configured separately via
   `TRINO_IMAGE_TAG`, `internal/config`, or `XTrinode.spec.valuesOverlay.image`. The current Trino
   compatibility target is upstream chart `trino-1.42.2` / app `480`.
@@ -104,8 +128,7 @@ make docker-push-operator IMG=ghcr.io/xtrinode/xtrinode-operator:0.1.0
 
 ```bash
 # Package chart
-cd helm/xtrinode-operator
-helm package . --version 0.1.0 --app-version 0.1.0
+helm package helm/xtrinode-operator
 
 # Output: xtrinode-operator-0.1.0.tgz
 ```
@@ -116,15 +139,9 @@ helm package . --version 0.1.0 --app-version 0.1.0
    - Chart packaged and uploaded to GitHub Releases
    - Download: `https://github.com/xtrinode/xtrinode/releases/download/v0.1.0/xtrinode-operator-0.1.0.tgz`
 
-2. **OCI Registry** (Future):
-
-   ```bash
-   helm push xtrinode-operator-0.1.0.tgz oci://ghcr.io/xtrinode/xtrinode-operator-chart
-   ```
-
-3. **Helm Repository** (Future):
-   - Host chart repository (e.g., GitHub Pages)
-   - Add repo: `helm repo add xtrinode https://xtrinode.github.io/xtrinode/charts`
+2. **OCI Registry / Helm Repository**:
+   - Not implemented.
+   - Do not expect release CI to push Helm charts to GHCR OCI repositories or a Helm repository.
 
 ---
 
@@ -142,7 +159,11 @@ helm package . --version 0.1.0 --app-version 0.1.0
 ### **2. Create Release PR**
 
 ```bash
-# 1. Update chart version fields, appVersion fields, and umbrella dependency versions:
+# 1. Update release metadata:
+#    - For a GitHub/Helm release, update helm/xtrinode/Chart.yaml version.
+#    - For a component image release, update that component chart appVersion.
+#    - For a component chart version bump, update that component chart version and
+#      the matching umbrella dependency version.
 #    helm/xtrinode-api-server/Chart.yaml
 #    helm/xtrinode-gateway/Chart.yaml
 #    helm/xtrinode-operator/Chart.yaml
@@ -163,12 +184,12 @@ When a release PR opened from an explicit CODEOWNER-owned branch is merged to `m
 CODEOWNER, GitHub Actions automatically:
 
 1. Runs tests
-2. Creates the annotated release tag
-3. Builds Linux amd64 Docker images
-4. Pushes images to `ghcr.io`
-5. Packages Helm charts
-6. Creates GitHub Release
-7. Uploads Helm charts to the release
+2. Creates the annotated release tag when the umbrella chart version changed
+3. Builds Linux amd64 Docker images only for components whose `appVersion` changed
+4. Pushes changed images to `ghcr.io`
+5. Packages Helm charts when the umbrella chart version changed
+6. Creates GitHub Release when the umbrella chart version changed
+7. Uploads Helm charts to the release when the umbrella chart version changed
 
 ### **4. Verify Release**
 
@@ -224,14 +245,17 @@ through `package.json` and `package-lock.json`.
 
 ### **On Release PR Merge**
 
-1. **Detect Version**: From the updated umbrella chart version
+1. **Detect Chart Release**: From the updated umbrella chart version
 2. **Authorize**: Confirm the PR author, branch owner, and merger are explicit CODEOWNERS
-3. **Tag**: Create `vMAJOR.MINOR.PATCH` from the chart version after CI passes
-4. **Scan**: Build and Trivy-scan each release image before pushing tags
-5. **Build**: Linux amd64 Docker images
-6. **Push**: Images with component image tags (`0.1.0`, `0.1`, `0`, `latest`)
-7. **Package**: Helm charts
-8. **Release**: Create GitHub Release with notes and chart artifacts
+3. **Tag**: Create `v<umbrella-version>` from the umbrella chart version after CI passes
+4. **Detect Images**: Compare each component chart `appVersion` independently
+5. **Guard Tags**: Refuse conflicting existing exact image tags before publishing
+6. **Scan**: Build and Trivy-scan each changed component image before pushing tags
+7. **Build**: Linux amd64 Docker images for changed components
+8. **Push**: Changed images with component image tags (`0.1.0`, `0.1`, `0`, `latest` for stable
+   versions; exact tag only for prereleases)
+9. **Package**: Helm charts when the umbrella chart version changed
+10. **Release**: Create GitHub Release with notes and chart artifacts when the umbrella chart version changed
 
 ---
 
@@ -244,8 +268,9 @@ through `package.json` and `package-lock.json`.
   `ghcr.io/<owner>/xtrinode-operator`,
   `ghcr.io/<owner>/xtrinode-api-server`,
   `ghcr.io/<owner>/xtrinode-gateway`
-- **Tags**: Component image version, major.minor, major, latest
+- **Tags**: Stable component image version, major.minor, major, latest; prerelease exact tag only
 - **Architecture**: linux/amd64
+- **Trigger**: Per-component chart `appVersion` changes
 
 ### **Helm Charts** → GitHub Releases
 
@@ -255,7 +280,21 @@ through `package.json` and `package-lock.json`.
   `xtrinode-operator-<version>.tgz`,
   `xtrinode-api-server-<version>.tgz`,
   `xtrinode-gateway-<version>.tgz`
-- **Future**: OCI registry (`ghcr.io/<owner>/xtrinode-operator-chart`)
+- **Trigger**: Umbrella chart `version` changes
+- **Not published**: OCI Helm chart publishing is not implemented; release charts are GitHub
+  Release assets only.
+
+### **Coverage Reports** → GitHub Actions Artifacts
+
+- **Location**: Pull request and main-branch workflow runs
+- **Format**: `coverage-report` artifact containing `xtrinode/coverage.out`
+- **Retention**: 7 days
+- **Release assets**: Coverage reports are not attached to GitHub Releases
+
+### **Terraform** → Validation Only
+
+- Terraform CI validates configuration. Release CI does not publish Terraform state, plans, modules,
+  or artifacts.
 
 ### **Source Code** → GitHub Repository
 
@@ -272,15 +311,22 @@ through `package.json` and `package-lock.json`.
 ```makefile
 GIT_TAG ?= $(shell git describe --tags --exact-match 2>/dev/null || true)
 VERSION ?= $(if $(GIT_TAG),$(patsubst v%,%,$(GIT_TAG)),dev)
-IMAGE_VERSION ?= $(shell awk '/^appVersion:/ {print $$2; exit}' helm/xtrinode/Chart.yaml 2>/dev/null | tr -d '"' || echo "$(VERSION)")
-IMAGE_TAG ?= $(if $(GIT_TAG),$(IMAGE_VERSION),$(VERSION))
-CLOUD_IMAGE_TAG ?= $(if $(filter dev,$(IMAGE_TAG)),$(IMAGE_VERSION),$(IMAGE_TAG))
+OPERATOR_IMAGE_VERSION ?= $(shell awk '/^appVersion:/ {print $$2; exit}' helm/xtrinode-operator/Chart.yaml 2>/dev/null | tr -d '"' || echo "dev")
+GATEWAY_IMAGE_VERSION ?= $(shell awk '/^appVersion:/ {print $$2; exit}' helm/xtrinode-gateway/Chart.yaml 2>/dev/null | tr -d '"' || echo "dev")
+API_SERVER_IMAGE_VERSION ?= $(shell awk '/^appVersion:/ {print $$2; exit}' helm/xtrinode-api-server/Chart.yaml 2>/dev/null | tr -d '"' || echo "dev")
+OPERATOR_IMAGE_TAG ?= $(if $(GIT_TAG),$(OPERATOR_IMAGE_VERSION),dev)
+GATEWAY_IMAGE_TAG ?= $(if $(GIT_TAG),$(GATEWAY_IMAGE_VERSION),dev)
+API_SERVER_IMAGE_TAG ?= $(if $(GIT_TAG),$(API_SERVER_IMAGE_VERSION),dev)
+OPERATOR_CLOUD_IMAGE_TAG ?= $(if $(filter dev,$(OPERATOR_IMAGE_TAG)),$(OPERATOR_IMAGE_VERSION),$(OPERATOR_IMAGE_TAG))
+GATEWAY_CLOUD_IMAGE_TAG ?= $(if $(filter dev,$(GATEWAY_IMAGE_TAG)),$(GATEWAY_IMAGE_VERSION),$(GATEWAY_IMAGE_TAG))
+API_SERVER_CLOUD_IMAGE_TAG ?= $(if $(filter dev,$(API_SERVER_IMAGE_TAG)),$(API_SERVER_IMAGE_VERSION),$(API_SERVER_IMAGE_TAG))
 ```
 
-`VERSION` identifies the XTrinode release when the checkout is exactly on a release tag. `IMAGE_TAG`
-identifies the default local control-plane image tag and resolves to the same chart `appVersion` on
-release tags. `CLOUD_IMAGE_TAG` keeps cloud publish/deploy defaults on `appVersion` instead of
-publishing the local `dev` tag by accident.
+`VERSION` identifies the umbrella chart release when the checkout is exactly on a release tag.
+Component image tag defaults resolve from each component chart `appVersion` on release tags and to
+`dev` otherwise. Cloud publish/deploy defaults are component-specific: each `*_CLOUD_IMAGE_TAG`
+uses that component's chart `appVersion` when the matching local `*_IMAGE_TAG` would otherwise be
+`dev`.
 
 ### **In GitHub Actions**
 
@@ -299,12 +345,12 @@ Release version detection lives in `scripts/ci/prepare-release.sh` and is called
 ## Best Practices
 
 1. **Release Through PRs**: Do not push release tags manually
-2. **Update Chart.yaml deliberately**: Keep all XTrinode chart `version` fields, umbrella dependency
-   versions, and `appVersion` fields in sync on the XTrinode release version.
+2. **Update Chart.yaml deliberately**: Keep umbrella dependency versions aligned with the matching
+   component chart versions. Bump component `appVersion` fields only for images that should publish.
 3. **Test Before Release**: Run full test suite and linting
 4. **Document Changes**: Keep docs and PR descriptions clear enough for generated release notes
 5. **Image Builds**: Keep release image builds on the release publishing path
-6. **Immutable Tags**: Never overwrite version tags (use new version)
+6. **Immutable Tags**: Never overwrite exact version tags (use a new component `appVersion`)
 7. **Release Notes**: Include meaningful release notes in GitHub Releases
 
 ---

--- a/scripts/ci/prepare-release.sh
+++ b/scripts/ci/prepare-release.sh
@@ -13,14 +13,69 @@ output() {
   printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT}"
 }
 
+current_version="$(chart_field helm/xtrinode/Chart.yaml version)"
+current_app_version="$(chart_field helm/xtrinode/Chart.yaml appVersion)"
+target_sha="$(git rev-parse HEAD)"
+
 output should_release false
 output should_publish_images false
-output target_sha "$(git rev-parse HEAD)"
+output image_matrix '{"include":[]}'
+output target_sha "${target_sha}"
+output version "${current_version}"
+output app_version "${current_app_version}"
+output tag "v${current_version}"
+
+for component in $(release_components); do
+  output "${component//-/_}_chart_version" "$(chart_field "$(component_chart_path "${component}")" version)"
+  output "${component//-/_}_image_version" "$(chart_field "$(component_chart_path "${component}")" appVersion)"
+done
 
 if [ "${BEFORE_SHA}" = "0000000000000000000000000000000000000000" ]; then
   echo "Initial branch push; skipping release."
   exit 0
 fi
+
+previous_version="$(chart_field_at_ref "${BEFORE_SHA}" helm/xtrinode/Chart.yaml version)"
+
+if [ -z "${previous_version}" ]; then
+  echo "No previous XTrinode umbrella chart version found at ${BEFORE_SHA}; initial project import does not create a release."
+  exit 0
+fi
+
+if ! release_metadata_changed_since "${BEFORE_SHA}"; then
+  echo "Release metadata did not change; skipping release and image publishing."
+  exit 0
+fi
+
+validate_release_version_metadata
+
+should_release=false
+if [ "${current_version}" != "${previous_version}" ]; then
+  should_release=true
+fi
+
+should_publish_images=false
+matrix_entries=""
+for component in $(release_components); do
+  chart="$(component_chart_path "${component}")"
+  current_image_version="$(chart_field "${chart}" appVersion)"
+  previous_image_version="$(chart_field_at_ref "${BEFORE_SHA}" "${chart}" appVersion)"
+
+  if [ "${current_image_version}" != "${previous_image_version}" ]; then
+    should_publish_images=true
+    entry="$(printf '{"component":"%s","image":"%s","package":"%s","port":"%s","version":"%s"}' \
+      "${component}" \
+      "$(component_image_name "${component}")" \
+      "$(component_package "${component}")" \
+      "$(component_port "${component}")" \
+      "${current_image_version}")"
+    if [ -z "${matrix_entries}" ]; then
+      matrix_entries="${entry}"
+    else
+      matrix_entries="${matrix_entries},${entry}"
+    fi
+  fi
+done
 
 pr_number="$(
   gh api \
@@ -70,76 +125,60 @@ if [ -z "${pr_head_owner}" ]; then
   exit 1
 fi
 
-current_version="$(awk '/^version:/ {print $2; exit}' helm/xtrinode/Chart.yaml | tr -d '"')"
-current_image_version="$(release_image_version)"
-previous_version="$(
-  git show "${BEFORE_SHA}:helm/xtrinode/Chart.yaml" 2>/dev/null |
-    awk '/^version:/ {print $2; exit}' |
-    tr -d '"' || true
-)"
-previous_image_version="$(
-  git show "${BEFORE_SHA}:helm/xtrinode/Chart.yaml" 2>/dev/null |
-    awk '/^appVersion:/ {print $2; exit}' |
-    tr -d '"' || true
-)"
-
 output pr_number "${pr_number}"
 output pr_author "${pr_author}"
 output pr_head_owner "${pr_head_owner}"
 output merged_by "${merged_by}"
-output version "${current_version}"
-output image_version "${current_image_version}"
-output tag "v${current_version}"
-
-if [ "${current_version}" = "${previous_version}" ]; then
-  echo "Chart version did not change (${current_version}); skipping release."
-  exit 0
-fi
-
-if [ -z "${previous_version}" ]; then
-  echo "No previous XTrinode chart version found at ${BEFORE_SHA}; initial project import does not create a release."
-  exit 0
-fi
-
-validate_release_version_metadata "${current_version}"
-
-if [ "${current_image_version}" != "${previous_image_version}" ]; then
-  output should_publish_images true
-fi
 
 owners="$(codeowners_at_ref "${BEFORE_SHA}")"
 
 if ! printf '%s\n' "${owners}" | grep -Fxq "@${pr_author}"; then
   echo "::error::PR #${pr_number} was opened by @${pr_author}, who is not an explicit CODEOWNER."
-  echo "::error::Release tags are only created from PRs opened by users listed in .github/CODEOWNERS."
+  echo "::error::Release metadata is only published from PRs opened by users listed in .github/CODEOWNERS."
   exit 1
 fi
 
 if ! printf '%s\n' "${owners}" | grep -Fxq "@${pr_head_owner}"; then
   echo "::error::PR #${pr_number} branch is owned by @${pr_head_owner}, not an explicit CODEOWNER."
-  echo "::error::Release tags are only created from PR branches owned by .github/CODEOWNERS users."
+  echo "::error::Release metadata is only published from PR branches owned by .github/CODEOWNERS users."
   exit 1
 fi
 
 if ! printf '%s\n' "${owners}" | grep -Fxq "@${merged_by}"; then
   echo "::error::PR #${pr_number} was merged by @${merged_by}, who is not an explicit CODEOWNER."
-  echo "::error::Release tags are only created when the PR merger is listed in .github/CODEOWNERS."
+  echo "::error::Release metadata is only published when the PR merger is listed in .github/CODEOWNERS."
   exit 1
 fi
 
-git fetch --tags --force
-if git show-ref --tags --verify --quiet "refs/tags/v${current_version}"; then
-  existing_tag_sha="$(git rev-list -n 1 "v${current_version}")"
-  target_sha="$(git rev-parse HEAD)"
-  if [ "${existing_tag_sha}" != "${target_sha}" ]; then
-    echo "::error::Tag v${current_version} already exists at ${existing_tag_sha}, expected ${target_sha}."
-    echo "::error::Bump the chart version before release."
-    exit 1
+if [ "${should_release}" = true ]; then
+  git fetch --tags --force
+  if git show-ref --tags --verify --quiet "refs/tags/v${current_version}"; then
+    existing_tag_sha="$(git rev-list -n 1 "v${current_version}")"
+    if [ "${existing_tag_sha}" != "${target_sha}" ]; then
+      echo "::error::Tag v${current_version} already exists at ${existing_tag_sha}, expected ${target_sha}."
+      echo "::error::Bump the umbrella chart version before release."
+      exit 1
+    fi
+    echo "Tag v${current_version} already exists at the target commit; continuing release rerun."
   fi
-  echo "Tag v${current_version} already exists at the target commit; continuing release rerun."
+  output should_release true
 fi
 
-output should_release true
-echo "Release v${current_version} will be created from PR #${pr_number}."
-echo "Release image version: ${current_image_version}."
+if [ "${should_publish_images}" = true ]; then
+  output should_publish_images true
+  output image_matrix "{\"include\":[${matrix_entries}]}"
+fi
+
+if [ "${should_release}" = true ]; then
+  echo "GitHub Release v${current_version} will be created from PR #${pr_number}."
+else
+  echo "Umbrella chart version did not change; no GitHub Release tag will be created."
+fi
+
+if [ "${should_publish_images}" = true ]; then
+  echo "Changed component images will be published to GHCR: ${matrix_entries}."
+else
+  echo "No component appVersion changed; no Docker images will be published."
+fi
+
 echo "Release PR author: @${pr_author}; branch owner: @${pr_head_owner}; merger: @${merged_by}."

--- a/scripts/ci/release-image-preflight.sh
+++ b/scripts/ci/release-image-preflight.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+: "${RELEASE_IMAGE:?RELEASE_IMAGE is required}"
+: "${RELEASE_IMAGE_VERSION:?RELEASE_IMAGE_VERSION is required}"
+: "${TARGET_SHA:?TARGET_SHA is required}"
+
+DOCKER="${DOCKER:-docker}"
+
+output() {
+  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT}"
+}
+
+restore_stable_floating_tags() {
+  local exact_ref="${1:?exact image ref is required}"
+  local major major_minor minor_rest tag
+
+  if [[ "${RELEASE_IMAGE_VERSION}" == *-* ]]; then
+    return
+  fi
+
+  major="${RELEASE_IMAGE_VERSION%%.*}"
+  minor_rest="${RELEASE_IMAGE_VERSION#*.}"
+  major_minor="${major}.${minor_rest%%.*}"
+
+  for tag in "${major_minor}" "${major}" latest; do
+    echo "Ensuring ${RELEASE_IMAGE}:${tag} points at ${exact_ref}."
+    "${DOCKER}" buildx imagetools create --tag "${RELEASE_IMAGE}:${tag}" "${exact_ref}"
+  done
+}
+
+exact_ref="${RELEASE_IMAGE}:${RELEASE_IMAGE_VERSION}"
+
+if ! manifest_error="$("${DOCKER}" manifest inspect "${exact_ref}" 2>&1 >/dev/null)"; then
+  if printf '%s\n' "${manifest_error}" | grep -Eiq 'manifest unknown|not found|no such manifest'; then
+    echo "No existing exact release image tag found: ${exact_ref}."
+    output exact_tag_exists false
+    output should_push true
+    exit 0
+  fi
+
+  echo "::error::Could not verify whether exact release image tag exists: ${exact_ref}."
+  echo "::error::Failing closed to avoid overwriting an existing release image tag."
+  if [ -n "${manifest_error}" ]; then
+    echo "::error::docker manifest inspect: ${manifest_error}"
+  fi
+  exit 1
+fi
+
+output exact_tag_exists true
+
+echo "Exact release image tag already exists: ${exact_ref}. Verifying image labels before rerun recovery."
+"${DOCKER}" pull "${exact_ref}" >/dev/null
+
+revision="$("${DOCKER}" image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "${exact_ref}" 2>/dev/null || true)"
+version="$("${DOCKER}" image inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' "${exact_ref}" 2>/dev/null || true)"
+
+if [ "${revision}" != "${TARGET_SHA}" ]; then
+  echo "::error::${exact_ref} already exists with revision '${revision:-missing}', expected '${TARGET_SHA}'."
+  echo "::error::Do not overwrite exact release image tags. Bump the component appVersion or repair the registry manually."
+  exit 1
+fi
+
+if [ "${version}" != "${RELEASE_IMAGE_VERSION}" ]; then
+  echo "::error::${exact_ref} already exists with version label '${version:-missing}', expected '${RELEASE_IMAGE_VERSION}'."
+  echo "::error::Do not overwrite exact release image tags. Bump the component appVersion or repair the registry manually."
+  exit 1
+fi
+
+restore_stable_floating_tags "${exact_ref}"
+
+output should_push false
+echo "Existing exact release image tag matches ${TARGET_SHA}; skipping rebuild and exact-tag push."

--- a/scripts/ci/release-lib.sh
+++ b/scripts/ci/release-lib.sh
@@ -14,6 +14,22 @@ chart_field() {
   ' "${chart}"
 }
 
+chart_field_at_ref() {
+  local ref="${1:?git ref is required}"
+  local chart="${2:?chart path is required}"
+  local field="${3:?chart field is required}"
+
+  git show "${ref}:${chart}" 2>/dev/null |
+    awk -v key="${field}:" '
+      $1 == key {
+        value = $2
+        gsub(/"/, "", value)
+        print value
+        exit
+      }
+    ' || true
+}
+
 dependency_version() {
   local dependency="${1:?dependency name is required}"
 
@@ -33,6 +49,67 @@ dependency_version() {
   ' helm/xtrinode/Chart.yaml
 }
 
+dependency_version_at_ref() {
+  local ref="${1:?git ref is required}"
+  local dependency="${2:?dependency name is required}"
+
+  git show "${ref}:helm/xtrinode/Chart.yaml" 2>/dev/null |
+    awk -v dependency="${dependency}" '
+      $1 == "-" && $2 == "name:" {
+        name = $3
+        gsub(/"/, "", name)
+        in_dependency = (name == dependency)
+        next
+      }
+      in_dependency && $1 == "version:" {
+        version = $2
+        gsub(/"/, "", version)
+        print version
+        exit
+      }
+    ' || true
+}
+
+dependency_lock_version() {
+  local dependency="${1:?dependency name is required}"
+
+  awk -v dependency="${dependency}" '
+    $1 == "-" && $2 == "name:" {
+      name = $3
+      gsub(/"/, "", name)
+      in_dependency = (name == dependency)
+      next
+    }
+    in_dependency && $1 == "version:" {
+      version = $2
+      gsub(/"/, "", version)
+      print version
+      exit
+    }
+  ' helm/xtrinode/Chart.lock
+}
+
+dependency_lock_version_at_ref() {
+  local ref="${1:?git ref is required}"
+  local dependency="${2:?dependency name is required}"
+
+  git show "${ref}:helm/xtrinode/Chart.lock" 2>/dev/null |
+    awk -v dependency="${dependency}" '
+      $1 == "-" && $2 == "name:" {
+        name = $3
+        gsub(/"/, "", name)
+        in_dependency = (name == dependency)
+        next
+      }
+      in_dependency && $1 == "version:" {
+        version = $2
+        gsub(/"/, "", version)
+        print version
+        exit
+      }
+    ' || true
+}
+
 codeowners_at_ref() {
   local ref="${1:?git ref is required}"
 
@@ -48,59 +125,159 @@ codeowners_at_ref() {
     sort -u
 }
 
-release_image_version() {
-  chart_field helm/xtrinode/Chart.yaml appVersion
+release_components() {
+  printf '%s\n' operator gateway api-server
+}
+
+component_chart_path() {
+  local component="${1:?component is required}"
+
+  case "${component}" in
+    operator) printf '%s\n' helm/xtrinode-operator/Chart.yaml ;;
+    gateway) printf '%s\n' helm/xtrinode-gateway/Chart.yaml ;;
+    api-server) printf '%s\n' helm/xtrinode-api-server/Chart.yaml ;;
+    *)
+      echo "unknown release component: ${component}" >&2
+      return 1
+      ;;
+  esac
+}
+
+component_dependency_name() {
+  local component="${1:?component is required}"
+
+  case "${component}" in
+    operator) printf '%s\n' xtrinode-operator ;;
+    gateway) printf '%s\n' xtrinode-gateway ;;
+    api-server) printf '%s\n' xtrinode-api-server ;;
+    *)
+      echo "unknown release component: ${component}" >&2
+      return 1
+      ;;
+  esac
+}
+
+component_image_name() {
+  local component="${1:?component is required}"
+
+  case "${component}" in
+    operator) printf '%s\n' xtrinode-operator ;;
+    gateway) printf '%s\n' xtrinode-gateway ;;
+    api-server) printf '%s\n' xtrinode-api-server ;;
+    *)
+      echo "unknown release component: ${component}" >&2
+      return 1
+      ;;
+  esac
+}
+
+component_package() {
+  local component="${1:?component is required}"
+
+  case "${component}" in
+    operator) printf '%s\n' ./cmd/operator ;;
+    gateway) printf '%s\n' ./cmd/gateway ;;
+    api-server) printf '%s\n' ./cmd/api-server ;;
+    *)
+      echo "unknown release component: ${component}" >&2
+      return 1
+      ;;
+  esac
+}
+
+component_port() {
+  local component="${1:?component is required}"
+
+  case "${component}" in
+    operator) printf '%s\n' 8081 ;;
+    gateway) printf '%s\n' 8080 ;;
+    api-server) printf '%s\n' 8081 ;;
+    *)
+      echo "unknown release component: ${component}" >&2
+      return 1
+      ;;
+  esac
+}
+
+validate_semver() {
+  local value="${1:-}"
+  local label="${2:?label is required}"
+  local prerelease_identifier release_version_regex
+
+  prerelease_identifier='(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)'
+  release_version_regex="^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-(${prerelease_identifier})(\\.${prerelease_identifier})*)?$"
+
+  if ! [[ "${value}" =~ ${release_version_regex} ]]; then
+    echo "::error::${label} '${value:-missing}' is not a valid release version."
+    echo "::error::Expected MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-PRERELEASE; build metadata is not supported in Docker tags."
+    exit 1
+  fi
 }
 
 validate_release_version_metadata() {
-  local chart_version="${1:?release chart version is required}"
-  local image_version
-  local chart actual_chart_version app_version dependency version
+  local umbrella_version umbrella_app_version
+  local app_version chart chart_version component dependency lock_version version
 
-  image_version="$(release_image_version)"
+  umbrella_version="$(chart_field helm/xtrinode/Chart.yaml version)"
+  umbrella_app_version="$(chart_field helm/xtrinode/Chart.yaml appVersion)"
 
-  if ! [[ "${chart_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-    echo "::error::Chart version '${chart_version}' is not a valid SemVer release version."
-    exit 1
-  fi
+  validate_semver "${umbrella_version}" "Umbrella chart version"
+  validate_semver "${umbrella_app_version}" "Umbrella chart appVersion"
 
-  if ! [[ "${image_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-    echo "::error::Image appVersion '${image_version:-missing}' is not a valid SemVer version."
-    exit 1
-  fi
-
-  if [ "${image_version}" != "${chart_version}" ]; then
-    echo "::error::Image appVersion '${image_version}' must match XTrinode chart version '${chart_version}'."
-    exit 1
-  fi
-
-  for chart in \
-    helm/xtrinode/Chart.yaml \
-    helm/xtrinode-operator/Chart.yaml \
-    helm/xtrinode-api-server/Chart.yaml \
-    helm/xtrinode-gateway/Chart.yaml
-  do
-    actual_chart_version="$(chart_field "${chart}" version)"
+  for component in $(release_components); do
+    chart="$(component_chart_path "${component}")"
+    dependency="$(component_dependency_name "${component}")"
+    chart_version="$(chart_field "${chart}" version)"
     app_version="$(chart_field "${chart}" appVersion)"
-    if [ "${actual_chart_version}" != "${chart_version}" ]; then
-      echo "::error::${chart} version is ${actual_chart_version:-missing}, expected ${chart_version}."
-      exit 1
-    fi
-    if [ "${app_version}" != "${image_version}" ]; then
-      echo "::error::${chart} appVersion is ${app_version:-missing}, expected image version ${image_version}."
-      exit 1
-    fi
-  done
-
-  for dependency in \
-    xtrinode-operator \
-    xtrinode-api-server \
-    xtrinode-gateway
-  do
     version="$(dependency_version "${dependency}")"
+    lock_version="$(dependency_lock_version "${dependency}")"
+
+    validate_semver "${chart_version}" "${chart} version"
+    validate_semver "${app_version}" "${chart} appVersion"
+
     if [ "${version}" != "${chart_version}" ]; then
       echo "::error::helm/xtrinode/Chart.yaml dependency ${dependency} version is ${version:-missing}, expected ${chart_version}."
       exit 1
     fi
+
+    if [ "${lock_version}" != "${chart_version}" ]; then
+      echo "::error::helm/xtrinode/Chart.lock dependency ${dependency} version is ${lock_version:-missing}, expected ${chart_version}."
+      echo "::error::Run helm dependency update helm/xtrinode after component chart version changes."
+      exit 1
+    fi
   done
+}
+
+release_metadata_changed_since() {
+  local ref="${1:?git ref is required}"
+  local component dependency path
+
+  if [ "$(chart_field helm/xtrinode/Chart.yaml version)" != "$(chart_field_at_ref "${ref}" helm/xtrinode/Chart.yaml version)" ]; then
+    return 0
+  fi
+
+  if [ "$(chart_field helm/xtrinode/Chart.yaml appVersion)" != "$(chart_field_at_ref "${ref}" helm/xtrinode/Chart.yaml appVersion)" ]; then
+    return 0
+  fi
+
+  for component in $(release_components); do
+    path="$(component_chart_path "${component}")"
+    dependency="$(component_dependency_name "${component}")"
+
+    if [ "$(chart_field "${path}" version)" != "$(chart_field_at_ref "${ref}" "${path}" version)" ]; then
+      return 0
+    fi
+    if [ "$(chart_field "${path}" appVersion)" != "$(chart_field_at_ref "${ref}" "${path}" appVersion)" ]; then
+      return 0
+    fi
+
+    if [ "$(dependency_version "${dependency}")" != "$(dependency_version_at_ref "${ref}" "${dependency}")" ]; then
+      return 0
+    fi
+    if [ "$(dependency_lock_version "${dependency}")" != "$(dependency_lock_version_at_ref "${ref}" "${dependency}")" ]; then
+      return 0
+    fi
+  done
+
+  return 1
 }

--- a/scripts/ci/release-pr-policy.sh
+++ b/scripts/ci/release-pr-policy.sh
@@ -10,36 +10,31 @@ source "${script_dir}/release-lib.sh"
 
 git fetch origin "${BASE_REF}" --depth=1
 
-current_version="$(awk '/^version:/ {print $2; exit}' helm/xtrinode/Chart.yaml | tr -d '"')"
-previous_version="$(
-  git show "FETCH_HEAD:helm/xtrinode/Chart.yaml" 2>/dev/null |
-    awk '/^version:/ {print $2; exit}' |
-    tr -d '"' || true
-)"
+previous_version="$(chart_field_at_ref FETCH_HEAD helm/xtrinode/Chart.yaml version)"
 
 if [ -z "${previous_version}" ]; then
-  echo "No previous XTrinode chart version found on ${BASE_REF}; release PR policy does not apply."
+  echo "No previous XTrinode umbrella chart version found on ${BASE_REF}; release PR policy does not apply."
   exit 0
 fi
 
-if [ "${current_version}" = "${previous_version}" ]; then
-  echo "Chart version did not change; release PR policy does not apply."
+if ! release_metadata_changed_since FETCH_HEAD; then
+  echo "Release metadata did not change; release PR policy does not apply."
   exit 0
 fi
 
-validate_release_version_metadata "${current_version}"
+validate_release_version_metadata
 
 owners="$(codeowners_at_ref FETCH_HEAD)"
 
 if ! printf '%s\n' "${owners}" | grep -Fxq "@${PR_AUTHOR}"; then
   echo "::error::Release PR was opened by @${PR_AUTHOR}, who is not an explicit CODEOWNER."
-  echo "::error::Only an explicit CODEOWNER may open a release version-bump PR."
+  echo "::error::Only an explicit CODEOWNER may open a release metadata PR."
   exit 1
 fi
 
 if ! printf '%s\n' "${owners}" | grep -Fxq "@${HEAD_REPO_OWNER}"; then
   echo "::error::Release PR branch is owned by @${HEAD_REPO_OWNER}, not an explicit CODEOWNER."
-  echo "::error::Release version-bump PR branches must be owned by an explicit CODEOWNER."
+  echo "::error::Release metadata PR branches must be owned by an explicit CODEOWNER."
   exit 1
 fi
 

--- a/scripts/deploy-aws.sh
+++ b/scripts/deploy-aws.sh
@@ -33,14 +33,24 @@ AWS="${AWS:-aws}"
 CURL="${CURL:-curl}"
 OPENSSL="${OPENSSL:-openssl}"
 
+chart_app_version() {
+  local chart="$1"
+  local version
+
+  version="$(awk '/^appVersion:/ {print $2; exit}' "$chart" 2>/dev/null | tr -d '"' || true)"
+  if [ -z "$version" ]; then
+    echo "ERROR: Could not read appVersion from $chart" >&2
+    exit 1
+  fi
+  printf '%s\n' "$version"
+}
+
 # Overridable via environment
 AWS_PROFILE="${AWS_PROFILE:-default}"
 AWS_REGION="${AWS_REGION:-us-east-1}"
-DEFAULT_IMAGE_VERSION="$(
-  awk '/^appVersion:/ {print $2; exit}' "$ROOT_DIR/helm/xtrinode/Chart.yaml" 2>/dev/null |
-    tr -d '"' || true
-)"
-VERSION="${VERSION:-${DEFAULT_IMAGE_VERSION:-0.1.0}}"
+OPERATOR_IMAGE_TAG="${OPERATOR_IMAGE_TAG:-$(chart_app_version "$ROOT_DIR/helm/xtrinode-operator/Chart.yaml")}"
+API_SERVER_IMAGE_TAG="${API_SERVER_IMAGE_TAG:-$(chart_app_version "$ROOT_DIR/helm/xtrinode-api-server/Chart.yaml")}"
+GATEWAY_IMAGE_TAG="${GATEWAY_IMAGE_TAG:-$(chart_app_version "$ROOT_DIR/helm/xtrinode-gateway/Chart.yaml")}"
 CLUSTER_NAME="${CLUSTER_NAME:-xtrinode-eks-test}"
 ENVIRONMENT="${ENVIRONMENT:-testing}"
 POSTGRES_PASSWORD="${TF_VAR_postgres_admin_password:-}"
@@ -108,12 +118,21 @@ postgres_enabled() {
     grep -Eq '^[[:space:]]*postgres_enabled[[:space:]]*=[[:space:]]*true([[:space:]#]|$)' "$TF_DIR/terraform.tfvars"
 }
 
+component_image_tag() {
+  case "$1" in
+    operator) printf '%s\n' "$OPERATOR_IMAGE_TAG" ;;
+    api-server) printf '%s\n' "$API_SERVER_IMAGE_TAG" ;;
+    gateway) printf '%s\n' "$GATEWAY_IMAGE_TAG" ;;
+    *) fail "Unknown component: $1" ;;
+  esac
+}
+
 # Verify AWS credentials
 AWS_ACCOUNT_ID=$("$AWS" sts get-caller-identity --profile "$AWS_PROFILE" --query Account --output text 2>/dev/null) \
   || fail "AWS credentials not configured. Run: aws configure --profile $AWS_PROFILE"
 ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 ok "AWS Account: $AWS_ACCOUNT_ID  Region: $AWS_REGION  Registry: $ECR_REGISTRY"
-ok "XTrinode image tag: $VERSION"
+ok "Image tags: operator=$OPERATOR_IMAGE_TAG api-server=$API_SERVER_IMAGE_TAG gateway=$GATEWAY_IMAGE_TAG"
 
 if [ -z "$API_SERVER_AUTH_TOKEN" ]; then
   API_SERVER_AUTH_TOKEN="$(random_token)"
@@ -210,12 +229,13 @@ if [ "$SKIP_BUILD" = false ]; then
   for comp in "${COMPONENTS[@]}"; do
     IFS=':' read -r name app_package app_port <<< "$comp"
     image_name="xtrinode-${name}"
-    tag="${ECR_REGISTRY}/${image_name}:${VERSION}"
+    image_tag="$(component_image_tag "$name")"
+    tag="${ECR_REGISTRY}/${image_name}:${image_tag}"
     info "  Building ${image_name}..."
     "$DOCKER" build \
       --build-arg APP_PACKAGE="$app_package" \
       --build-arg APP_PORT="$app_port" \
-      --build-arg VERSION="$VERSION" \
+      --build-arg VERSION="$image_tag" \
       --build-arg GIT_COMMIT="$GIT_COMMIT" \
       --build-arg BUILD_DATE="$BUILD_DATE" \
       -t "$tag" \
@@ -232,9 +252,10 @@ if [ "$SKIP_BUILD" = false ]; then
   for comp in "${COMPONENTS[@]}"; do
     IFS=':' read -r name _ <<< "$comp"
     image_name="xtrinode-${name}"
+    image_tag="$(component_image_tag "$name")"
     info "  Pushing ${image_name}..."
-    "$DOCKER" push "${ECR_REGISTRY}/${image_name}:${VERSION}"
-    ok "  Pushed: ${ECR_REGISTRY}/${image_name}:${VERSION}"
+    "$DOCKER" push "${ECR_REGISTRY}/${image_name}:${image_tag}"
+    ok "  Pushed: ${ECR_REGISTRY}/${image_name}:${image_tag}"
   done
 else
   info "Step 3/5: Skipping Docker build (--skip-build)"
@@ -337,7 +358,7 @@ info "  Deploying xtrinode-operator..."
   --take-ownership \
   --namespace "$OPERATOR_NAMESPACE" \
   --set image.repository="${ECR_REGISTRY}/xtrinode-operator" \
-  --set image.tag="$VERSION" \
+  --set image.tag="$OPERATOR_IMAGE_TAG" \
   --set image.pullPolicy=Always \
   --set keda.enabled=true \
   --set webhook.enabled="$WEBHOOK_ENABLED" \
@@ -353,7 +374,7 @@ info "  Deploying xtrinode-api-server..."
   --take-ownership \
   --namespace "$OPERATOR_NAMESPACE" \
   --set image.repository="${ECR_REGISTRY}/xtrinode-api-server" \
-  --set image.tag="$VERSION" \
+  --set image.tag="$API_SERVER_IMAGE_TAG" \
   --set image.pullPolicy=Always \
   --set apiServer.auth.enabled=true \
   --set apiServer.auth.existingSecret="$API_SERVER_AUTH_SECRET" \
@@ -369,7 +390,7 @@ info "  Deploying xtrinode-gateway..."
   --force \
   --namespace "$GATEWAY_NAMESPACE" \
   --set image.repository="${ECR_REGISTRY}/xtrinode-gateway" \
-  --set image.tag="$VERSION" \
+  --set image.tag="$GATEWAY_IMAGE_TAG" \
   --set image.pullPolicy=Always \
   --set replicaCount="$GATEWAY_REPLICA_COUNT" \
   --set gateway.redis.enabled="$GATEWAY_REDIS_ENABLED" \
@@ -395,7 +416,10 @@ echo ""
 echo "  Cluster:    $CLUSTER_NAME"
 echo "  Region:     $AWS_REGION"
 echo "  Registry:   $ECR_REGISTRY"
-echo "  Image tag:  $VERSION"
+echo "  Image tags:"
+echo "    operator:   $OPERATOR_IMAGE_TAG"
+echo "    api-server: $API_SERVER_IMAGE_TAG"
+echo "    gateway:    $GATEWAY_IMAGE_TAG"
 echo ""
 echo "  Namespaces:"
 echo "    Operator + API Server:  $OPERATOR_NAMESPACE"

--- a/scripts/deploy-azure.sh
+++ b/scripts/deploy-azure.sh
@@ -31,11 +31,21 @@ MAKE="${MAKE:-make}"
 AZ="${AZ:-az}"
 OPENSSL="${OPENSSL:-openssl}"
 
-DEFAULT_IMAGE_VERSION="$(
-  awk '/^appVersion:/ {print $2; exit}' "$ROOT_DIR/helm/xtrinode/Chart.yaml" 2>/dev/null |
-    tr -d '"' || true
-)"
-VERSION="${VERSION:-${DEFAULT_IMAGE_VERSION:-0.1.0}}"
+chart_app_version() {
+  local chart="$1"
+  local version
+
+  version="$(awk '/^appVersion:/ {print $2; exit}' "$chart" 2>/dev/null | tr -d '"' || true)"
+  if [ -z "$version" ]; then
+    echo "ERROR: Could not read appVersion from $chart" >&2
+    exit 1
+  fi
+  printf '%s\n' "$version"
+}
+
+OPERATOR_IMAGE_TAG="${OPERATOR_IMAGE_TAG:-$(chart_app_version "$ROOT_DIR/helm/xtrinode-operator/Chart.yaml")}"
+API_SERVER_IMAGE_TAG="${API_SERVER_IMAGE_TAG:-$(chart_app_version "$ROOT_DIR/helm/xtrinode-api-server/Chart.yaml")}"
+GATEWAY_IMAGE_TAG="${GATEWAY_IMAGE_TAG:-$(chart_app_version "$ROOT_DIR/helm/xtrinode-gateway/Chart.yaml")}"
 
 AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:-${ARM_SUBSCRIPTION_ID:-}}"
 AZURE_REGION="${AZURE_REGION:-eastus}"
@@ -105,6 +115,15 @@ postgres_enabled() {
     grep -Eq '^[[:space:]]*postgres_enabled[[:space:]]*=[[:space:]]*true([[:space:]#]|$)' "$TF_DIR/terraform.tfvars"
 }
 
+component_image_tag() {
+  case "$1" in
+    operator) printf '%s\n' "$OPERATOR_IMAGE_TAG" ;;
+    api-server) printf '%s\n' "$API_SERVER_IMAGE_TAG" ;;
+    gateway) printf '%s\n' "$GATEWAY_IMAGE_TAG" ;;
+    *) fail "Unknown component: $1" ;;
+  esac
+}
+
 terraform_vars=()
 append_terraform_vars() {
   terraform_vars=(
@@ -157,7 +176,7 @@ AZURE_SUBSCRIPTION_ID="$("$AZ" account show --query id -o tsv 2>/dev/null)" \
   || fail "Azure CLI is not authenticated. Run: az login"
 [ -n "$AZURE_SUBSCRIPTION_ID" ] || fail "Azure subscription ID is empty."
 ok "Azure subscription: $AZURE_SUBSCRIPTION_ID  Region: $AZURE_REGION"
-ok "XTrinode image tag: $VERSION"
+ok "Image tags: operator=$OPERATOR_IMAGE_TAG api-server=$API_SERVER_IMAGE_TAG gateway=$GATEWAY_IMAGE_TAG"
 
 append_terraform_vars
 
@@ -233,16 +252,16 @@ if [ "$SKIP_BUILD" = false ]; then
   for comp in "${COMPONENTS[@]}"; do
     IFS=':' read -r name app_package app_port <<< "$comp"
     image_name="xtrinode-${name}"
-    tag="${ACR_LOGIN_SERVER}/${image_name}:${VERSION}"
+    image_tag="$(component_image_tag "$name")"
+    tag="${ACR_LOGIN_SERVER}/${image_name}:${image_tag}"
     info "Building ${image_name}"
     "$DOCKER" build \
       --build-arg APP_PACKAGE="$app_package" \
       --build-arg APP_PORT="$app_port" \
-      --build-arg VERSION="$VERSION" \
+      --build-arg VERSION="$image_tag" \
       --build-arg GIT_COMMIT="$GIT_COMMIT" \
       --build-arg BUILD_DATE="$BUILD_DATE" \
       -t "$tag" \
-      -t "${ACR_LOGIN_SERVER}/${image_name}:latest" \
       -f "$DOCKERFILE" \
       "$OPERATOR_DIR"
   done
@@ -253,8 +272,8 @@ if [ "$SKIP_BUILD" = false ]; then
   for comp in "${COMPONENTS[@]}"; do
     IFS=':' read -r name _ <<< "$comp"
     image_name="xtrinode-${name}"
-    "$DOCKER" push "${ACR_LOGIN_SERVER}/${image_name}:${VERSION}"
-    "$DOCKER" push "${ACR_LOGIN_SERVER}/${image_name}:latest"
+    image_tag="$(component_image_tag "$name")"
+    "$DOCKER" push "${ACR_LOGIN_SERVER}/${image_name}:${image_tag}"
   done
 else
   info "Step 3/5: Skipping Docker build (--skip-build)"
@@ -355,7 +374,7 @@ info "Deploying xtrinode-operator"
   --take-ownership \
   --namespace "$OPERATOR_NAMESPACE" \
   --set image.repository="${ACR_LOGIN_SERVER}/xtrinode-operator" \
-  --set image.tag="$VERSION" \
+  --set image.tag="$OPERATOR_IMAGE_TAG" \
   --set image.pullPolicy=Always \
   --set keda.enabled=true \
   --set webhook.enabled="$WEBHOOK_ENABLED" \
@@ -369,7 +388,7 @@ info "Deploying xtrinode-api-server"
   --take-ownership \
   --namespace "$OPERATOR_NAMESPACE" \
   --set image.repository="${ACR_LOGIN_SERVER}/xtrinode-api-server" \
-  --set image.tag="$VERSION" \
+  --set image.tag="$API_SERVER_IMAGE_TAG" \
   --set image.pullPolicy=Always \
   --set apiServer.auth.enabled=true \
   --set apiServer.auth.existingSecret="$API_SERVER_AUTH_SECRET" \
@@ -383,7 +402,7 @@ info "Deploying xtrinode-gateway"
   --force \
   --namespace "$GATEWAY_NAMESPACE" \
   --set image.repository="${ACR_LOGIN_SERVER}/xtrinode-gateway" \
-  --set image.tag="$VERSION" \
+  --set image.tag="$GATEWAY_IMAGE_TAG" \
   --set image.pullPolicy=Always \
   --set replicaCount="$GATEWAY_REPLICA_COUNT" \
   --set gateway.redis.enabled="$GATEWAY_REDIS_ENABLED" \
@@ -409,7 +428,10 @@ cat <<EOF
   Region:     $AZURE_REGION
   Resource group: $RESOURCE_GROUP_NAME
   Registry:   $ACR_LOGIN_SERVER
-  Image tag:  $VERSION
+  Image tags:
+    operator:   $OPERATOR_IMAGE_TAG
+    api-server: $API_SERVER_IMAGE_TAG
+    gateway:    $GATEWAY_IMAGE_TAG
 
   Namespaces:
     Operator + API Server:  $OPERATOR_NAMESPACE

--- a/scripts/deploy-gcp.sh
+++ b/scripts/deploy-gcp.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Deploy XTrinode operator to GCP GKE cluster
+# Deploy the XTrinode control plane to a GCP GKE cluster
 # Prerequisites: see docs/TOOLING.md for versions.
 #   - gcloud auth, gke-gcloud-auth-plugin, Helm, kubectl, and openssl
 
@@ -12,17 +12,27 @@ KUBECTL="${KUBECTL:-kubectl}"
 MAKE="${MAKE:-make}"
 GCLOUD="${GCLOUD:-gcloud}"
 OPENSSL="${OPENSSL:-openssl}"
-DEFAULT_IMAGE_VERSION="$(
-  awk '/^appVersion:/ {print $2; exit}' "${ROOT_DIR}/helm/xtrinode/Chart.yaml" 2>/dev/null |
-    tr -d '"' || true
-)"
+
+chart_app_version() {
+  local chart="$1"
+  local version
+
+  version="$(awk '/^appVersion:/ {print $2; exit}' "$chart" 2>/dev/null | tr -d '"' || true)"
+  if [ -z "$version" ]; then
+    echo "ERROR: Could not read appVersion from $chart" >&2
+    exit 1
+  fi
+  printf '%s\n' "$version"
+}
 
 PROJECT_ID="${GCP_PROJECT_ID:-project-40642592-0c4f-4ce1-9d6}"
 CLUSTER_NAME="${GCP_CLUSTER_NAME:-xtrinode-gke-test}"
 ZONE="${GCP_ZONE:-us-central1-a}"
 REGION="${GCP_REGION:-us-central1}"
 REGISTRY="${REGION}-docker.pkg.dev/${PROJECT_ID}"
-VERSION="${VERSION:-${DEFAULT_IMAGE_VERSION:-0.1.0}}"
+OPERATOR_IMAGE_TAG="${OPERATOR_IMAGE_TAG:-$(chart_app_version "${ROOT_DIR}/helm/xtrinode-operator/Chart.yaml")}"
+API_SERVER_IMAGE_TAG="${API_SERVER_IMAGE_TAG:-$(chart_app_version "${ROOT_DIR}/helm/xtrinode-api-server/Chart.yaml")}"
+GATEWAY_IMAGE_TAG="${GATEWAY_IMAGE_TAG:-$(chart_app_version "${ROOT_DIR}/helm/xtrinode-gateway/Chart.yaml")}"
 NAMESPACE="${OPERATOR_NAMESPACE:-xtrinode-system}"
 GATEWAY_REPLICA_COUNT="${GATEWAY_REPLICA_COUNT:-1}"
 GATEWAY_REDIS_ENABLED="${GATEWAY_REDIS_ENABLED:-false}"
@@ -48,7 +58,10 @@ PROMETHEUS_URL="http://prometheus-operated.${OBSERVABILITY_NAMESPACE}.svc.cluste
 
 echo "=== Deploying XTrinode to GCP ==="
 echo "Project: $PROJECT_ID, Cluster: $CLUSTER_NAME"
-echo "XTrinode image tag: $VERSION"
+echo "Image tags:"
+echo "  operator:   $OPERATOR_IMAGE_TAG"
+echo "  api-server: $API_SERVER_IMAGE_TAG"
+echo "  gateway:    $GATEWAY_IMAGE_TAG"
 echo "Gateway replicas: $GATEWAY_REPLICA_COUNT, Redis enabled: $GATEWAY_REDIS_ENABLED"
 echo "Gateway auth enabled: $GATEWAY_AUTH_ENABLED"
 echo "Prometheus enabled: $PROMETHEUS_ENABLED, Vector enabled: $VECTOR_ENABLED"
@@ -160,7 +173,7 @@ echo "Deploying XTrinode operator..."
   --take-ownership \
   --namespace "$NAMESPACE" \
   --set image.repository="${REGISTRY}/xtrinode-operator/xtrinode-operator" \
-  --set image.tag="$VERSION" \
+  --set image.tag="$OPERATOR_IMAGE_TAG" \
   --set image.pullPolicy=Always \
   --set keda.enabled=true \
   --set webhook.enabled="$WEBHOOK_ENABLED" \
@@ -177,7 +190,7 @@ echo "Deploying XTrinode API server..."
   --namespace "$NAMESPACE" \
   --create-namespace \
   --set image.repository="${REGISTRY}/xtrinode-api-server/xtrinode-api-server" \
-  --set image.tag="$VERSION" \
+  --set image.tag="$API_SERVER_IMAGE_TAG" \
   --set image.pullPolicy=Always \
   --set apiServer.auth.enabled=true \
   --set apiServer.auth.existingSecret="$API_SERVER_AUTH_SECRET" \
@@ -195,7 +208,7 @@ echo "Deploying XTrinode gateway..."
   --namespace xtrinode-gateway \
   --create-namespace \
   --set image.repository="${REGISTRY}/xtrinode-gateway/xtrinode-gateway" \
-  --set image.tag="$VERSION" \
+  --set image.tag="$GATEWAY_IMAGE_TAG" \
   --set image.pullPolicy=Always \
   --set replicaCount="$GATEWAY_REPLICA_COUNT" \
   --set gateway.redis.enabled="$GATEWAY_REDIS_ENABLED" \


### PR DESCRIPTION
## Summary

- Decouples XTrinode release versioning from component Docker image versioning.
- Uses the umbrella chart `version` as the GitHub release/tag trigger.
- Publishes operator, gateway, and API server images independently from their component chart `appVersion` changes.
- Keeps component chart `version` fields independent while requiring umbrella dependency metadata and lock files to stay aligned.
- Adds GHCR exact-tag preflight behavior so reruns can recover cleanly and conflicting existing tags fail closed.
- Removes the legacy single-version image publishing path from release and provider deployment ergonomics.
- Adds local `pre-commit` hooks backed by existing Make targets.

## Validation

- [x] Relevant local checks passed.
- [x] Skipped checks are explained below.

Checks run:

- `make lint-yaml`
- `make lint-shell`
- `make lint-markdown`
- `make lint-helm`
- `make pre-commit-run`
- `bash -n` for release and cloud deploy scripts
- `shellcheck -x -P scripts/ci` for release and cloud deploy scripts
- `git diff --check`
- `prepare-release` dry run against the current branch
- Release image preflight fake-registry cases for missing tag, transient registry error, matching rerun, and conflicting tag
- Make dry runs for manual release refusal and Docker image tag behavior

Skipped checks:

- Full live release publishing was not run.
- Cloud-provider live deployment smoke tests were not run.
- `actionlint` was not run locally because it is not installed in the local toolchain.

## Risk

Medium. This changes release automation behavior, image publishing semantics, and provider deployment inputs. The release path remains CODEOWNER-gated, exact image tag conflicts fail closed, and reruns of already-published matching tags are treated as recoverable.

Merging this branch as-is should not create a GitHub release, Git tag, or image publish because the release and app versions remain `0.1.0`.

## Release Impact

- [ ] This PR does not change release versioning, image publishing, or Helm chart packaging.
- [x] This PR changes release behavior and the impact is described below.

Release behavior after this PR:

- Umbrella chart `version` changes drive GitHub release/tag creation.
- Operator, gateway, and API server `appVersion` changes independently drive GHCR image publishing for only the changed component.
- Docker image publishing does not require an umbrella chart release.
- An umbrella chart release does not force Docker image publishing when component app versions are unchanged.
- Component chart versions can move independently from each other and from image versions.
- Umbrella dependency metadata and `Chart.lock` must match the selected component chart versions.

## Notes

- The branch keeps all current release metadata at `0.1.0`.
- Release ownership expectations remain documented in `.github/CODEOWNERS` and `docs/CODEOWNERS.md`.
- Versioning and packaging behavior is documented in `docs/VERSIONING_AND_PACKAGING.md`.
- The `pre-commit` config uses repository-relative commands and delegates to existing Make targets.
